### PR TITLE
Harden enclave/host interface

### DIFF
--- a/enclave/ecalls.cpp
+++ b/enclave/ecalls.cpp
@@ -43,6 +43,8 @@ int enclave_XGDMatrixCreateFromEncryptedFile(const char *fname, int silent, DMat
 
 int enclave_XGBoosterCreate(DMatrixHandle dmat_handles[], size_t handle_lengths[], bst_ulong len, BoosterHandle* out) {
   LOG(DEBUG) << "Ecall: XGBoosterCreate";
+
+  // Validate buffers and copy to enclave memory
   DMatrixHandle dmats[len];
   for (int i = 0; i < len; i++) {
     char* name = dmat_handles[i];
@@ -71,6 +73,8 @@ int enclave_XGBoosterBoostOneIter(BoosterHandle handle, DMatrixHandle dtrain, bs
 
 int enclave_XGBoosterEvalOneIter(BoosterHandle handle, int iter, DMatrixHandle dmat_handles[], size_t handle_lengths[], const char* evnames[], size_t names_lengths[], bst_ulong len, char** out_str) {
   LOG(DEBUG) << "Ecall: XGBoosterEvalOneIter";
+
+  // Validate buffers and copy to enclave memory
   char* dmats[len];
   char* eval_names[len];
   for (int i = 0; i < len; i++) {
@@ -129,6 +133,8 @@ int enclave_XGBoosterDumpModelWithFeatures(BoosterHandle handle,
                                    xgboost::bst_ulong* len,
                                    char*** out_models) {
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelWithFeatures";
+
+  // Validate buffers and copy to enclave memory
   char** fname_cpy = (char**) malloc(sizeof(char*) * fnum);
   char** ftype_cpy = (char**) malloc(sizeof(char*) * fnum);
   size_t name_len;
@@ -158,6 +164,8 @@ int enclave_XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
                                    xgboost::bst_ulong* len,
                                    char*** out_models) {
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelWithFeatures";
+
+  // Validate buffers and copy to enclave memory
   char** fname_cpy = (char**) malloc(sizeof(char*) * fnum);
   char** ftype_cpy = (char**) malloc(sizeof(char*) * fnum);
   size_t name_len;
@@ -280,6 +288,8 @@ int enclave_add_client_key(
 
 void enclave_RabitInit(int argc, char **argv, size_t arg_lengths[]) {
   LOG(DEBUG) << "Ecall: RabitInit";
+
+  // Validate buffers and copy to enclave memory
   char* args[argc];
   for (int i = 0; i < argc; i++) {
     char* arg = argv[i];

--- a/enclave/ecalls.cpp
+++ b/enclave/ecalls.cpp
@@ -53,7 +53,11 @@ int enclave_XGBoosterCreate(DMatrixHandle dmat_handles[], size_t handle_lengths[
     dmats[i] = strndup(name, nlen);
     dmats[i][nlen] = '\0';
   }
-  return XGBoosterCreate(dmats, len, out);
+  int ret = XGBoosterCreate(dmats, len, out);
+  for (int i = 0; i < len; i++) {
+    free(dmats[i]);
+  }
+  return ret;
 }
 
 int enclave_XGBoosterSetParam(BoosterHandle handle, const char *name, const char *value) {
@@ -91,7 +95,12 @@ int enclave_XGBoosterEvalOneIter(BoosterHandle handle, int iter, DMatrixHandle d
     eval_names[i] = strndup(name, nlen);
     eval_names[i][nlen] = '\0';
   }
-  return XGBoosterEvalOneIter(handle, iter, dmats, (const char**) eval_names, len, (const char**) out_str);
+  int ret = XGBoosterEvalOneIter(handle, iter, dmats, (const char**) eval_names, len, (const char**) out_str);
+  for (int i = 0; i < len; i++) {
+    free(dmats[i]);
+    free(eval_names[i]);
+  }
+  return ret;
 }
 
 int enclave_XGBoosterLoadModel(BoosterHandle handle, const char *fname) {
@@ -135,8 +144,8 @@ int enclave_XGBoosterDumpModelWithFeatures(BoosterHandle handle,
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelWithFeatures";
 
   // Validate buffers and copy to enclave memory
-  char** fname_cpy = (char**) malloc(sizeof(char*) * fnum);
-  char** ftype_cpy = (char**) malloc(sizeof(char*) * fnum);
+  char* fname_cpy[fnum];
+  char* ftype_cpy[fnum];
   size_t name_len;
   size_t type_len;
   for (int i = 0; i < fnum; i++) {
@@ -151,7 +160,12 @@ int enclave_XGBoosterDumpModelWithFeatures(BoosterHandle handle,
     ftype_cpy[i] = strndup(ftype[i], type_len);
     ftype_cpy[i][type_len] = '\0';
   }
-  return XGBoosterDumpModelWithFeatures(handle, (int) fnum, (const char**) fname_cpy, (const char**) ftype_cpy, with_stats, len, (const char***) out_models);
+  int ret = XGBoosterDumpModelWithFeatures(handle, (int) fnum, (const char**) fname_cpy, (const char**) ftype_cpy, with_stats, len, (const char***) out_models);
+  for (int i = 0; i < fnum; i++) {
+    free(fname_cpy[i]);
+    free(ftype_cpy[i]);
+  }
+  return ret;
 }
 int enclave_XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
                                    unsigned int fnum,
@@ -166,8 +180,8 @@ int enclave_XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelWithFeatures";
 
   // Validate buffers and copy to enclave memory
-  char** fname_cpy = (char**) malloc(sizeof(char*) * fnum);
-  char** ftype_cpy = (char**) malloc(sizeof(char*) * fnum);
+  char* fname_cpy[fnum];
+  char* ftype_cpy[fnum];
   size_t name_len;
   size_t type_len;
   for (int i = 0; i < fnum; i++) {
@@ -182,7 +196,12 @@ int enclave_XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
     ftype_cpy[i] = strndup(ftype[i], type_len);
     ftype_cpy[i][type_len] = '\0';
   }
-  return XGBoosterDumpModelExWithFeatures(handle, (int) fnum, (const char**) fname_cpy, (const char**) ftype_cpy, with_stats, format, len, (const char***) out_models);
+  int ret = XGBoosterDumpModelExWithFeatures(handle, (int) fnum, (const char**) fname_cpy, (const char**) ftype_cpy, with_stats, format, len, (const char***) out_models);
+  for (int i = 0; i < fnum; i++) {
+    free(fname_cpy[i]);
+    free(ftype_cpy[i]);
+  }
+  return ret;
 }
 int enclave_XGBoosterGetModelRaw(BoosterHandle handle, xgboost::bst_ulong *out_len, char **out_dptr) {
   LOG(DEBUG) << "Ecall: XGBoosterSerializeToBuffer";
@@ -299,6 +318,9 @@ void enclave_RabitInit(int argc, char **argv, size_t arg_lengths[]) {
     args[i][len] = '\0';
   }
   RabitInit(argc, args);
+  for (int i = 0; i < argc; i++) {
+    free(args[i]);
+  }
 }
 
 void enclave_RabitFinalize() {

--- a/enclave/ecalls.cpp
+++ b/enclave/ecalls.cpp
@@ -41,59 +41,62 @@ int enclave_XGDMatrixCreateFromEncryptedFile(const char *fname, int silent, DMat
   return XGDMatrixCreateFromEncryptedFile(fname, silent, out);
 }
 
-int enclave_XGBoosterCreate(const DMatrixHandle dmats[], bst_ulong len, BoosterHandle* out) {
+int enclave_XGBoosterCreate(DMatrixHandle dmat_handles[], size_t handle_lengths[], bst_ulong len, BoosterHandle* out) {
   LOG(DEBUG) << "Ecall: XGBoosterCreate";
+  DMatrixHandle dmats[len];
   for (int i = 0; i < len; i++) {
-      check_enclave_ptr(dmats[i]);
+    char* name = dmat_handles[i];
+    size_t nlen = handle_lengths[i];
+    check_host_buffer(name, nlen);
+    dmats[i] = strndup(name, nlen);
+    dmats[i][nlen] = '\0';
   }
   return XGBoosterCreate(dmats, len, out);
 }
 
 int enclave_XGBoosterSetParam(BoosterHandle handle, const char *name, const char *value) {
   LOG(DEBUG) << "Ecall: XGBoosterSetParam";
-  check_enclave_ptr(handle);
   return XGBoosterSetParam(handle, name, value);
 }
 
 int enclave_XGBoosterUpdateOneIter(BoosterHandle handle, int iter, DMatrixHandle dtrain) {
   LOG(DEBUG) << "Ecall: XGBoosterUpdateOneIter";
-  check_enclave_ptr(handle);
-  check_enclave_ptr(dtrain);
   return XGBoosterUpdateOneIter(handle, iter, dtrain);
 }
 
 int enclave_XGBoosterBoostOneIter(BoosterHandle handle, DMatrixHandle dtrain, bst_float *grad, bst_float *hess, xgboost::bst_ulong len) {
   LOG(DEBUG) << "Ecall: XGBoosterBoostOneIter";
-  check_enclave_ptr(handle);
-  check_enclave_ptr(dtrain);
   return XGBoosterBoostOneIter(handle, dtrain, grad, hess, len);
 }
 
-int enclave_XGBoosterEvalOneIter(BoosterHandle handle, int iter, DMatrixHandle dmats[], const char* evnames[], bst_ulong len, char** out_str) {
-  LOG(DEBUG) << "Ecall: XGBoosterEvalOneIter " << strlen(evnames[0]);
-  check_enclave_ptr(handle);
+int enclave_XGBoosterEvalOneIter(BoosterHandle handle, int iter, DMatrixHandle dmat_handles[], size_t handle_lengths[], const char* evnames[], size_t names_lengths[], bst_ulong len, char** out_str) {
+  LOG(DEBUG) << "Ecall: XGBoosterEvalOneIter";
+  char* dmats[len];
   char* eval_names[len];
   for (int i = 0; i < len; i++) {
-      check_enclave_ptr(dmats[i]);
-
-      const char* name = evnames[i];
-      size_t nlen = strlen(name) + 1;
-      check_host_buffer(name, nlen);
-      eval_names[i] = strndup(name, nlen);
-      eval_names[i][nlen] = '\0';
+    char* name = dmat_handles[i];
+    size_t nlen = handle_lengths[i];
+    check_host_buffer(name, nlen);
+    dmats[i] = strndup(name, nlen);
+    dmats[i][nlen] = '\0';
+  }
+  for (int i = 0; i < len; i++) {
+    const char* name = evnames[i];
+    size_t nlen = names_lengths[i];
+    check_host_buffer(name, nlen);
+    eval_names[i] = strndup(name, nlen);
+    eval_names[i][nlen] = '\0';
   }
   return XGBoosterEvalOneIter(handle, iter, dmats, (const char**) eval_names, len, (const char**) out_str);
 }
 
 int enclave_XGBoosterLoadModel(BoosterHandle handle, const char *fname) {
   LOG(DEBUG) << "Ecall: XGBoosterLoadModel";
-  check_enclave_ptr(handle);
   return XGBoosterLoadModel(handle, fname);
 }
 
 int enclave_XGBoosterSaveModel(BoosterHandle handle, const char *fname) {
   LOG(DEBUG) << "Ecall: XGBoosterSaveModel";
-  check_enclave_ptr(handle);
   return XGBoosterSaveModel(handle, fname);
 }
 
@@ -103,7 +106,6 @@ int enclave_XGBoosterDumpModel(BoosterHandle handle,
                        xgboost::bst_ulong* len,
                        char*** out_models) {
   LOG(DEBUG) << "Ecall: XGBoosterDumpModel";
-  check_enclave_ptr(handle);
   return XGBoosterDumpModel(handle, fmap, with_stats, len, (const char***) out_models);
 }
 
@@ -114,26 +116,26 @@ int enclave_XGBoosterDumpModelEx(BoosterHandle handle,
                        xgboost::bst_ulong* len,
                        char*** out_models) {
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelEx";
-  check_enclave_ptr(handle);
   return XGBoosterDumpModelEx(handle, fmap, with_stats, format, len, (const char***) out_models);
 }
 
 int enclave_XGBoosterDumpModelWithFeatures(BoosterHandle handle,
                                    unsigned int fnum,
                                    const char** fname,
+                                   size_t fname_lengths[],
                                    const char** ftype,
+                                   size_t ftype_lengths[],
                                    int with_stats,
                                    xgboost::bst_ulong* len,
                                    char*** out_models) {
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelWithFeatures";
-  check_enclave_ptr(handle);
   char** fname_cpy = (char**) malloc(sizeof(char*) * fnum);
   char** ftype_cpy = (char**) malloc(sizeof(char*) * fnum);
-  unsigned int name_len;
-  unsigned int type_len;
+  size_t name_len;
+  size_t type_len;
   for (int i = 0; i < fnum; i++) {
-    name_len = strlen(fname[i]) + 1;
-    type_len = strlen(ftype[i]) + 1;
+    name_len = fname_lengths[i];
+    type_len = ftype_lengths[i];
 
     check_host_buffer(fname[i], name_len);
     check_host_buffer(ftype[i], type_len);
@@ -148,20 +150,21 @@ int enclave_XGBoosterDumpModelWithFeatures(BoosterHandle handle,
 int enclave_XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
                                    unsigned int fnum,
                                    const char** fname,
+                                   size_t fname_lengths[],
                                    const char** ftype,
+                                   size_t ftype_lengths[],
                                    int with_stats,
                                    const char *format,
                                    xgboost::bst_ulong* len,
                                    char*** out_models) {
   LOG(DEBUG) << "Ecall: XGBoosterDumpModelWithFeatures";
-  check_enclave_ptr(handle);
   char** fname_cpy = (char**) malloc(sizeof(char*) * fnum);
   char** ftype_cpy = (char**) malloc(sizeof(char*) * fnum);
-  unsigned int name_len;
-  unsigned int type_len;
+  size_t name_len;
+  size_t type_len;
   for (int i = 0; i < fnum; i++) {
-    name_len = strlen(fname[i]) + 1;
-    type_len = strlen(ftype[i]) + 1;
+    name_len = fname_lengths[i];
+    type_len = ftype_lengths[i];
 
     check_host_buffer(fname[i], name_len);
     check_host_buffer(ftype[i], type_len);
@@ -175,69 +178,57 @@ int enclave_XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
 }
 int enclave_XGBoosterGetModelRaw(BoosterHandle handle, xgboost::bst_ulong *out_len, char **out_dptr) {
   LOG(DEBUG) << "Ecall: XGBoosterSerializeToBuffer";
-  check_enclave_ptr(handle);
   return XGBoosterGetModelRaw(handle, out_len, (const char**)out_dptr);
 }
 
 int enclave_XGBoosterLoadModelFromBuffer(BoosterHandle handle, const void* buf, xgboost::bst_ulong len) {
   LOG(DEBUG) << "Ecall: XGBoosterLoadModelFromBuffer";
-  check_enclave_ptr(handle);
   return XGBoosterLoadModelFromBuffer(handle, buf, len);
 }
 
 int enclave_XGBoosterPredict(BoosterHandle handle, DMatrixHandle dmat, int option_mask, unsigned ntree_limit, bst_ulong *len, uint8_t **out_result) {
   LOG(DEBUG) << "Ecall: XGBoosterPredict";
-  check_enclave_ptr(handle);
-  check_enclave_ptr(dmat);
   return XGBoosterPredict(handle, dmat, option_mask, ntree_limit, len, out_result);
 }
 
 int enclave_XGDMatrixGetFloatInfo(const DMatrixHandle handle, const char* field, bst_ulong *out_len, bst_float **out_dptr) {
   LOG(DEBUG) << "Ecall: XGDMatrixGetFloatInfo";
-  check_enclave_ptr(handle);
   return XGDMatrixGetFloatInfo(handle, field, out_len, (const bst_float**) out_dptr);
 }
 
 int enclave_XGDMatrixGetUintInfo(const DMatrixHandle handle, const char* field, bst_ulong *out_len, unsigned **out_dptr) {
   LOG(DEBUG) << "Ecall: XGDMatrixGetFloatInfo";
-  check_enclave_ptr(handle);
   return XGDMatrixGetUIntInfo(handle, field, out_len, (const unsigned**) out_dptr);
 }
 
 int enclave_XGDMatrixSetFloatInfo(DMatrixHandle handle, const char* field, const bst_float* info, bst_ulong len) {
   LOG(DEBUG) << "Ecall: XGDMatrixSetFloatInfo";
-  check_enclave_ptr(handle);
   return XGDMatrixSetFloatInfo(handle, field, info, len);
 }
 
 int enclave_XGDMatrixSetUIntInfo(DMatrixHandle handle, const char* field, const unsigned* info, bst_ulong len) {
   LOG(DEBUG) << "Ecall: XGDMatrixSetUIntInfo";
-  check_enclave_ptr(handle);
   return XGDMatrixSetUIntInfo(handle, field, info, len);
 }
 
 int enclave_XGDMatrixNumRow(const DMatrixHandle handle, bst_ulong *out) {
   LOG(DEBUG) << "Ecall: XGDMatrixNumRow";
-  check_enclave_ptr(handle);
   return XGDMatrixNumRow(handle, out);
 }
 
 int enclave_XGDMatrixNumCol(const DMatrixHandle handle, bst_ulong *out) {
   LOG(DEBUG) << "Ecall: XGDMatrixNumCol";
-  check_enclave_ptr(handle);
   return XGDMatrixNumCol(handle, out);
 }
 
 int enclave_XGBoosterGetAttr(BoosterHandle handle, const char* key, char** out, int* success) {
-    LOG(DEBUG) << "Ecall: XGBoosterGetAttr";
-    check_enclave_ptr(handle);
-    return XGBoosterGetAttr(handle, key, (const char** )out, success);
+  LOG(DEBUG) << "Ecall: XGBoosterGetAttr";
+  return XGBoosterGetAttr(handle, key, (const char** )out, success);
 }
 
 int enclave_XGBoosterGetAttrNames(BoosterHandle handle, bst_ulong* out_len, char*** out) {
-    LOG(DEBUG) << "Ecall: XGBoosterGetAttrNames";
-    check_enclave_ptr(handle);
-    return XGBoosterGetAttrNames(handle, out_len, (const char***) out);
+  LOG(DEBUG) << "Ecall: XGBoosterGetAttrNames";
+  return XGBoosterGetAttrNames(handle, out_len, (const char***) out);
 }
 
 int enclave_XGDMatrixFree(DMatrixHandle handle) {

--- a/enclave/ecalls.cpp
+++ b/enclave/ecalls.cpp
@@ -278,10 +278,17 @@ int enclave_add_client_key(
     return add_client_key(data, data_len, signature, sig_len);
 }
 
-// FIXME: check bounds
-void enclave_RabitInit(int argc, char **argv) {
+void enclave_RabitInit(int argc, char **argv, size_t arg_lengths[]) {
   LOG(DEBUG) << "Ecall: RabitInit";
-  RabitInit(argc, argv);
+  char* args[argc];
+  for (int i = 0; i < argc; i++) {
+    char* arg = argv[i];
+    size_t len = arg_lengths[i];
+    check_host_buffer(arg, len);
+    args[i] = strndup(arg, len);
+    args[i][len] = '\0';
+  }
+  RabitInit(argc, args);
 }
 
 void enclave_RabitFinalize() {

--- a/enclave/include/enclave_context.h
+++ b/enclave/include/enclave_context.h
@@ -55,23 +55,23 @@ class EnclaveContext {
       return m_private_key;
     }
 
+    // Note: Returned handle needs to be freed
     BoosterHandle add_booster(void* booster) {
       std::ostringstream oss;
       oss << "Booster_" << ++booster_ctr;
       auto str = oss.str();
       booster_map[str] = booster;
-      //BoosterHandle handle = const_cast<char*>(str.c_str());
       BoosterHandle handle = strdup(str.c_str());
       LOG(DEBUG) << "Added booster " << handle;
       return handle;
     }
 
+    // Note: Returned handle needs to be freed
     DMatrixHandle add_dmatrix(void* dmatrix) {
       std::ostringstream oss;
       oss << "DMatrix_" << ++dmatrix_ctr;
       auto str = oss.str();
       dmatrix_map[str] = dmatrix;
-      //DMatrixHandle handle = const_cast<char*>(str.c_str());
       DMatrixHandle handle = strdup(str.c_str());
       LOG(DEBUG) << "Added dmatrix " << handle;
       return handle;
@@ -91,7 +91,6 @@ class EnclaveContext {
 
     void* get_dmatrix(DMatrixHandle handle) {
       LOG(DEBUG) << "Getting dmatrix " << handle;
-      dmatrix_map.find(handle);
       std::string str(handle);
       std::unordered_map<std::string, void*>::const_iterator iter = dmatrix_map.find(str);
       if (iter == dmatrix_map.end()) {

--- a/enclave/include/enclave_context.h
+++ b/enclave/include/enclave_context.h
@@ -60,22 +60,19 @@ class EnclaveContext {
       oss << "Booster_" << ++booster_ctr;
       auto str = oss.str();
       booster_map[str] = booster;
-      BoosterHandle handle = const_cast<char*>(str.c_str());
-      booster_map[handle] = booster;
+      //BoosterHandle handle = const_cast<char*>(str.c_str());
+      BoosterHandle handle = strdup(str.c_str());
       LOG(DEBUG) << "Added booster " << handle;
       return handle;
     }
 
     DMatrixHandle add_dmatrix(void* dmatrix) {
-      LOG(DEBUG) << "Map size " << dmatrix_map.size();
-      for(auto kv : dmatrix_map) {
-        LOG(DEBUG) << kv.first;
-      } 
       std::ostringstream oss;
       oss << "DMatrix_" << ++dmatrix_ctr;
       auto str = oss.str();
       dmatrix_map[str] = dmatrix;
-      DMatrixHandle handle = const_cast<char*>(str.c_str());
+      //DMatrixHandle handle = const_cast<char*>(str.c_str());
+      DMatrixHandle handle = strdup(str.c_str());
       LOG(DEBUG) << "Added dmatrix " << handle;
       return handle;
     }
@@ -101,7 +98,6 @@ class EnclaveContext {
         LOG(FATAL) << "No such dmatrix oject";
         return NULL;
       } else {
-        LOG(DEBUG) << "Returning dmatrix " << handle;
         return iter->second;
       }
     }

--- a/enclave/include/enclave_context.h
+++ b/enclave/include/enclave_context.h
@@ -14,6 +14,15 @@ class EnclaveContext {
     uint8_t m_public_key[CIPHER_PK_SIZE];
     uint8_t m_private_key[CIPHER_PK_SIZE];
 
+     /* We maintain these maps to avoid having to pass out pointers to application code outside
+      * the enclave; instead, the application is given a string nickname that the enclave resolves
+      * to a pointer internally.
+      */
+    std::unordered_map<std::string, void*> booster_map;
+    std::unordered_map<std::string, void*> dmatrix_map;
+    int booster_ctr;
+    int dmatrix_ctr;
+
     // FIXME use array of fixed length instead of vector
     //std::unordered_map<std::string, std::vector<uint8_t>> client_keys;
     uint8_t client_key[CIPHER_KEY_SIZE];
@@ -22,6 +31,8 @@ class EnclaveContext {
     EnclaveContext() {
       generate_public_key();
       client_key_is_set = false;
+      booster_ctr = 0;
+      dmatrix_ctr = 0;
     }
 
   public:
@@ -42,6 +53,65 @@ class EnclaveContext {
 
     uint8_t* get_private_key() {
       return m_private_key;
+    }
+
+    BoosterHandle add_booster(void* booster) {
+      std::ostringstream oss;
+      oss << "Booster_" << ++booster_ctr;
+      auto str = oss.str();
+      booster_map[str] = booster;
+      BoosterHandle handle = const_cast<char*>(str.c_str());
+      booster_map[handle] = booster;
+      LOG(DEBUG) << "Added booster " << handle;
+      return handle;
+    }
+
+    DMatrixHandle add_dmatrix(void* dmatrix) {
+      LOG(DEBUG) << "Map size " << dmatrix_map.size();
+      for(auto kv : dmatrix_map) {
+        LOG(DEBUG) << kv.first;
+      } 
+      std::ostringstream oss;
+      oss << "DMatrix_" << ++dmatrix_ctr;
+      auto str = oss.str();
+      dmatrix_map[str] = dmatrix;
+      DMatrixHandle handle = const_cast<char*>(str.c_str());
+      LOG(DEBUG) << "Added dmatrix " << handle;
+      return handle;
+    }
+
+    void* get_booster(BoosterHandle handle) {
+      LOG(DEBUG) << "Getting booster " << handle;
+      std::string str(handle);
+      std::unordered_map<std::string, void*>::const_iterator iter = booster_map.find(str);
+      if (iter == booster_map.end()) {
+        LOG(FATAL) << "No such booster oject";
+        return NULL;
+      } else {
+        return iter->second;
+      }
+    }
+
+    void* get_dmatrix(DMatrixHandle handle) {
+      LOG(DEBUG) << "Getting dmatrix " << handle;
+      dmatrix_map.find(handle);
+      std::string str(handle);
+      std::unordered_map<std::string, void*>::const_iterator iter = dmatrix_map.find(str);
+      if (iter == dmatrix_map.end()) {
+        LOG(FATAL) << "No such dmatrix oject";
+        return NULL;
+      } else {
+        LOG(DEBUG) << "Returning dmatrix " << handle;
+        return iter->second;
+      }
+    }
+
+    void del_booster(BoosterHandle handle) {
+      booster_map.erase(handle);
+    }
+
+    void del_dmatrix(DMatrixHandle handle) {
+      dmatrix_map.erase(handle);
     }
 
     //bool get_client_key(std::string fname, uint8_t* key) {

--- a/enclave/src/c_api/c_api.cc
+++ b/enclave/src/c_api/c_api.cc
@@ -503,6 +503,7 @@ int XGDMatrixCreateFromEncryptedFile(const char *fname,
     void *mat = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split, true, key));
     char* out_str  = EnclaveContext::getInstance().add_dmatrix(mat);
     *out = oe_host_strndup(out_str, strlen(out_str));
+    free(out_str);
 #else
     *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split));
 #endif
@@ -523,6 +524,7 @@ int XGDMatrixCreateFromFile(const char *fname,
     void *mat = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split, false, NULL));
     char* out_str  = EnclaveContext::getInstance().add_dmatrix(mat);
     *out = oe_host_strndup(out_str, strlen(out_str));
+    free(out_str);
 #else
     *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split));
 #endif
@@ -1197,6 +1199,7 @@ XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
   void* booster = new Booster(mats);
   char* out_str = EnclaveContext::getInstance().add_booster(booster);
   *out = oe_host_strndup(out_str, strlen(out_str));
+  free(out_str);
 #else
   *out = new Booster(mats);
 #endif

--- a/enclave/src/c_api/c_api.cc
+++ b/enclave/src/c_api/c_api.cc
@@ -500,7 +500,9 @@ int XGDMatrixCreateFromEncryptedFile(const char *fname,
     char key[CIPHER_KEY_SIZE];
     EnclaveContext::getInstance().get_client_key((uint8_t*) key);
     //EnclaveContext::getInstance().get_client_key(fname, (uint8_t*) key);
-    *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split, true, key));
+    void *mat = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split, true, key));
+    char* out_str  = EnclaveContext::getInstance().add_dmatrix(mat);
+    *out = oe_host_strndup(out_str, strlen(out_str));
 #else
     *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split));
 #endif
@@ -518,7 +520,9 @@ int XGDMatrixCreateFromFile(const char *fname,
         load_row_split = true;
     }
 #ifdef __ENCLAVE__ // pass decryption key
-    *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split, false, NULL));
+    void *mat = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split, false, NULL));
+    char* out_str  = EnclaveContext::getInstance().add_dmatrix(mat);
+    *out = oe_host_strndup(out_str, strlen(out_str));
 #else
     *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, load_row_split));
 #endif
@@ -1009,7 +1013,13 @@ XGB_DLL int XGDMatrixSliceDMatrix(DMatrixHandle handle,
 XGB_DLL int XGDMatrixFree(DMatrixHandle handle) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  delete static_cast<std::shared_ptr<DMatrix>*>(mat);
+  EnclaveContext::getInstance().del_dmatrix(handle);
+#else
   delete static_cast<std::shared_ptr<DMatrix>*>(handle);
+#endif
   API_END();
 }
 
@@ -1030,8 +1040,14 @@ XGB_DLL int XGDMatrixSetFloatInfo(DMatrixHandle handle,
                           xgboost::bst_ulong len) {
   API_BEGIN();
   CHECK_HANDLE();
-  static_cast<std::shared_ptr<DMatrix>*>(handle)
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  static_cast<std::shared_ptr<DMatrix>*>(mat)
       ->get()->Info().SetInfo(field, info, kFloat32, len);
+#else
+  static_cast<std::shared_ptr<DMatrix>*>(handle)
+    ->get()->Info().SetInfo(field, info, kFloat32, len);
+#endif
   API_END();
 }
 
@@ -1041,8 +1057,14 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
                          xgboost::bst_ulong len) {
   API_BEGIN();
   CHECK_HANDLE();
-  static_cast<std::shared_ptr<DMatrix>*>(handle)
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  static_cast<std::shared_ptr<DMatrix>*>(mat)
       ->get()->Info().SetInfo(field, info, kUInt32, len);
+#else
+  static_cast<std::shared_ptr<DMatrix>*>(handle)
+    ->get()->Info().SetInfo(field, info, kUInt32, len);
+#endif
   API_END();
 }
 
@@ -1069,7 +1091,12 @@ XGB_DLL int XGDMatrixGetFloatInfo(const DMatrixHandle handle,
                                   const bst_float** out_dptr) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  const MetaInfo& info = static_cast<std::shared_ptr<DMatrix>*>(mat)->get()->Info();
+#else
   const MetaInfo& info = static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info();
+#endif
   const std::vector<bst_float>* vec = nullptr;
   if (!std::strcmp(field, "label")) {
     vec = &info.labels_.HostVector();
@@ -1097,7 +1124,12 @@ XGB_DLL int XGDMatrixGetUIntInfo(const DMatrixHandle handle,
                                  const unsigned **out_dptr) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  const MetaInfo& info = static_cast<std::shared_ptr<DMatrix>*>(mat)->get()->Info();
+#else
   const MetaInfo& info = static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info();
+#endif
   const std::vector<unsigned>* vec = nullptr;
   if (!std::strcmp(field, "root_index")) {
     vec = &info.root_index_;
@@ -1119,8 +1151,14 @@ XGB_DLL int XGDMatrixNumRow(const DMatrixHandle handle,
                             xgboost::bst_ulong *out) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  *out = static_cast<xgboost::bst_ulong>(
+      static_cast<std::shared_ptr<DMatrix>*>(mat)->get()->Info().num_row_);
+#else
   *out = static_cast<xgboost::bst_ulong>(
       static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_row_);
+#endif
   API_END();
 }
 
@@ -1128,8 +1166,14 @@ XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
                             xgboost::bst_ulong *out) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* mat = EnclaveContext::getInstance().get_dmatrix(handle);
+  *out = static_cast<size_t>(
+      static_cast<std::shared_ptr<DMatrix>*>(mat)->get()->Info().num_col_);
+#else
   *out = static_cast<size_t>(
       static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_col_);
+#endif
   API_END();
 }
 
@@ -1140,16 +1184,35 @@ XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
   API_BEGIN();
   std::vector<std::shared_ptr<DMatrix> > mats;
   for (xgboost::bst_ulong i = 0; i < len; ++i) {
+#ifdef __ENCLAVE__
+    void* mat = EnclaveContext::getInstance().get_dmatrix(dmats[i]);
+    LOG(DEBUG) << "Got matrix";
+    mats.push_back(*static_cast<std::shared_ptr<DMatrix>*>(mat));
+    LOG(DEBUG) << "Pushed matrix";
+#else
     mats.push_back(*static_cast<std::shared_ptr<DMatrix>*>(dmats[i]));
+#endif
   }
+#ifdef __ENCLAVE__
+  void* booster = new Booster(mats);
+  char* out_str = EnclaveContext::getInstance().add_booster(booster);
+  *out = oe_host_strndup(out_str, strlen(out_str));
+#else
   *out = new Booster(mats);
+#endif
   API_END();
 }
 
 XGB_DLL int XGBoosterFree(BoosterHandle handle) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* bst = EnclaveContext::getInstance().get_booster(handle);
+  delete static_cast<Booster*>(bst);
+  EnclaveContext::getInstance().del_dmatrix(handle);
+#else
   delete static_cast<Booster*>(handle);
+#endif
   API_END();
 }
 
@@ -1158,7 +1221,12 @@ XGB_DLL int XGBoosterSetParam(BoosterHandle handle,
                               const char *value) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  void* bst = EnclaveContext::getInstance().get_booster(handle);
+  static_cast<Booster*>(bst)->SetParam(name, value);
+#else
   static_cast<Booster*>(handle)->SetParam(name, value);
+#endif
   API_END();
 }
 
@@ -1167,9 +1235,15 @@ XGB_DLL int XGBoosterUpdateOneIter(BoosterHandle handle,
                                    DMatrixHandle dtrain) {
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+  auto *dtr =
+    static_cast<std::shared_ptr<DMatrix>*>(EnclaveContext::getInstance().get_dmatrix(dtrain));
+#else
   auto* bst = static_cast<Booster*>(handle);
   auto *dtr =
-      static_cast<std::shared_ptr<DMatrix>*>(dtrain);
+    static_cast<std::shared_ptr<DMatrix>*>(dtrain);
+#endif
   bst->LazyInit();
   bst->learner()->UpdateOneIter(iter, dtr->get());
   API_END();
@@ -1183,9 +1257,15 @@ XGB_DLL int XGBoosterBoostOneIter(BoosterHandle handle,
   HostDeviceVector<GradientPair> tmp_gpair;
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+  auto *dtr =
+    static_cast<std::shared_ptr<DMatrix>*>(EnclaveContext::getInstance().get_dmatrix(dtrain));
+#else
   auto* bst = static_cast<Booster*>(handle);
   auto* dtr =
       static_cast<std::shared_ptr<DMatrix>*>(dtrain);
+#endif
   tmp_gpair.Resize(len);
   std::vector<GradientPair>& tmp_gpair_h = tmp_gpair.HostVector();
   for (xgboost::bst_ulong i = 0; i < len; ++i) {
@@ -1206,12 +1286,21 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
   std::string& eval_str = XGBAPIThreadLocalStore::Get()->ret_str;
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+#else
   auto* bst = static_cast<Booster*>(handle);
+#endif
   std::vector<DMatrix*> data_sets;
   std::vector<std::string> data_names;
 
   for (xgboost::bst_ulong i = 0; i < len; ++i) {
+#ifdef __ENCLAVE__
+    data_sets.push_back(static_cast<std::shared_ptr<DMatrix>*>(
+          EnclaveContext::getInstance().get_dmatrix(dmats[i]))->get());
+#else
     data_sets.push_back(static_cast<std::shared_ptr<DMatrix>*>(dmats[i])->get());
+#endif
     data_names.emplace_back(evnames[i]);
   }
 
@@ -1240,11 +1329,19 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
     XGBAPIThreadLocalStore::Get()->ret_vec_float;
   API_BEGIN();
   CHECK_HANDLE();
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+#else
   auto *bst = static_cast<Booster*>(handle);
+#endif
   bst->LazyInit();
   HostDeviceVector<bst_float> tmp_preds;
   bst->learner()->Predict(
+#ifdef __ENCLAVE__
+      static_cast<std::shared_ptr<DMatrix>*>(EnclaveContext::getInstance().get_dmatrix(dmat))->get(),
+#else
       static_cast<std::shared_ptr<DMatrix>*>(dmat)->get(),
+#endif
       (option_mask & 1) != 0,
       &tmp_preds, ntree_limit,
       (option_mask & 2) != 0,
@@ -1323,7 +1420,7 @@ XGB_DLL int XGBoosterSaveModel(BoosterHandle handle, const char* fname) {
   raw_str.resize(0);
 
   common::MemoryBufferStream fo(&raw_str);
-  auto *bst = static_cast<Booster*>(handle);
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
   bst->LazyInit();
   bst->learner()->Save(&fo);
 
@@ -1385,7 +1482,7 @@ XGB_DLL int XGBoosterLoadModelFromBuffer(BoosterHandle handle,
       output);
 
   common::MemoryFixSizeBuffer fs((void*)output, len);  // NOLINT(*)
-  static_cast<Booster*>(handle)->LoadModel(&fs);
+  static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle))->LoadModel(&fs);
   free(output);
 #else
   common::MemoryFixSizeBuffer fs((void*)buf, len);  // NOLINT(*)
@@ -1403,7 +1500,11 @@ XGB_DLL int XGBoosterGetModelRaw(BoosterHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   common::MemoryBufferStream fo(&raw_str);
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+#else
   auto *bst = static_cast<Booster*>(handle);
+#endif
   bst->LazyInit();
   bst->learner()->Save(&fo);
 #ifdef __ENCLAVE__ // write results to host memory
@@ -1445,7 +1546,11 @@ inline void XGBoostDumpModelImpl(
     xgboost::bst_ulong* len,
     const char*** out_models) {
   std::vector<std::string>& str_vecs = XGBAPIThreadLocalStore::Get()->ret_vec_str;
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+#else
   auto *bst = static_cast<Booster*>(handle);
+#endif
   bst->LazyInit();
   str_vecs = bst->learner()->DumpModel(fmap, with_stats != 0, format);
 #ifndef __ENCLAVE__
@@ -1555,7 +1660,11 @@ XGB_DLL int XGBoosterGetAttr(BoosterHandle handle,
                      const char* key,
                      const char** out,
                      int* success) {
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+#else
   auto* bst = static_cast<Booster*>(handle);
+#endif
   std::string& ret_str = XGBAPIThreadLocalStore::Get()->ret_str;
   API_BEGIN();
   CHECK_HANDLE();
@@ -1590,7 +1699,11 @@ XGB_DLL int XGBoosterGetAttrNames(BoosterHandle handle,
                      const char*** out) {
   std::vector<std::string>& str_vecs = XGBAPIThreadLocalStore::Get()->ret_vec_str;
   std::vector<const char*>& charp_vecs = XGBAPIThreadLocalStore::Get()->ret_vec_charp;
+#ifdef __ENCLAVE__
+  auto* bst = static_cast<Booster*>(EnclaveContext::getInstance().get_booster(handle));
+#else
   auto *bst = static_cast<Booster*>(handle);
+#endif
   API_BEGIN();
   CHECK_HANDLE();
   str_vecs = bst->learner()->GetAttrNames();

--- a/enclave/xgboost.edl
+++ b/enclave/xgboost.edl
@@ -8,180 +8,187 @@ enclave {
         public int enclave_XGDMatrixCreateFromFile(
                 [in, string] const char *fname,
                 int silent,
-                [out] DMatrixHandle *out);
-
+                [out] char** handle);
+        
         public int enclave_XGDMatrixCreateFromEncryptedFile(
                 [in, string] const char *fname,
                 int silent,
-                [out] DMatrixHandle *out);
-
+                [out] char** handle);
+        
         public int enclave_XGBoosterCreate(
-                [in, count=len] const DMatrixHandle* dmats, 
+                [in, count=len] char** dmat_handles, 
+                [in, count=len] size_t* handle_lengths, 
                 bst_ulong len, 
-                [out] BoosterHandle* out);
-
+                [out] char** handle);
+        
         public int enclave_XGBoosterSetParam(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, string] const char *name,
                 [in, string] const char *value); 
-
+        
         public int enclave_XGBoosterUpdateOneIter(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 int iter,
-                DMatrixHandle dtrain);
-
+                [in, string] char* dtrain);
+        
         public int enclave_XGBoosterBoostOneIter(
-                BoosterHandle handle,
-                DMatrixHandle dtrain,
+                [in, string] char* handle,
+                [in, string] char* dtrain,
                 [in, count=len] bst_float *grad,
                 [in, count=len] bst_float *hess,
                 bst_ulong len);
-
+        
         public int enclave_XGBoosterEvalOneIter(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 int iter,
-                [in, count=len] DMatrixHandle* dmats,
+                [in, count=len] char** dmat_handles,
+                [in, count=len] size_t* handle_lengths,
                 [in, count=len] const char** evnames,
+                [in, count=len] size_t* name_lengths,
                 bst_ulong len,
                 [out] char** out_str);
-
+        
         public int enclave_XGBoosterPredict(
-                BoosterHandle handle,
-                DMatrixHandle dmat,
+                [in, string] char* handle,
+                [in, string] char* dmat,
                 int option_mask,
                 unsigned ntree_limit,
                 [out] bst_ulong *out_len,
                 [out] uint8_t **out_result);
         
         public int enclave_XGDMatrixGetFloatInfo(
-                DMatrixHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* field,
                 [out] bst_ulong *out_len,
                 [out] bst_float **out_dptr);
-
+        
         public int enclave_XGDMatrixGetUintInfo(
-                DMatrixHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* field,
                 [out] bst_ulong *out_len,
                 [out] unsigned **out_dptr);
-
+        
         public int enclave_XGDMatrixSetFloatInfo(
-                DMatrixHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* field,
                 [in] const bst_float* info,
                 bst_ulong len);
-
+        
         public int enclave_XGDMatrixSetUIntInfo(
-                DMatrixHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* field,
                 [in] const unsigned* info,
                 bst_ulong len);
-
+        
         public int enclave_XGDMatrixNumRow(
-                DMatrixHandle handle,
+                [in, string] char* handle,
                 [out] bst_ulong *out);
-
+        
         public int enclave_XGDMatrixNumCol(
-                DMatrixHandle handle,
+                [in, string] char* handle,
                 [out] bst_ulong *out);
-
+        
         public int enclave_XGBoosterGetAttr(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* key,
                 [out] char** out,
                 [out] int* success);
-
+        
         public int enclave_XGBoosterGetAttrNames(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [out] bst_ulong* out_len,
                 [out] char*** out);
-
+        
         public int enclave_XGBoosterLoadModel(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* fname);
         
         public int enclave_XGBoosterSaveModel(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* fname);
-
+        
         public int enclave_XGBoosterDumpModel(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* fmap,
                 int with_stats,
                 [out] bst_ulong* len,
                 [out] char*** out_models);
-
+        
         public int enclave_XGBoosterDumpModelEx(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, string] const char* fmap,
                 int with_stats,
                 [in, string] const char* format,
                 [out] bst_ulong* len,
                 [out] char*** out_models);
-
+        
         public int enclave_XGBoosterDumpModelWithFeatures(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 unsigned int fnum,
                 [in, count=fnum] const char** fname,
+                [in, count=fnum] size_t* fname_lengths,
                 [in, count=fnum] const char** ftype,
+                [in, count=fnum] size_t* ftype_lengths,
                 int with_stats,
                 [out] bst_ulong* len,
                 [out] char*** out_models);
-
+        
         public int enclave_XGBoosterDumpModelExWithFeatures(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 unsigned int fnum,
                 [in, count=fnum] const char** fname,
+                [in, count=fnum] size_t* fname_lengths,
                 [in, count=fnum] const char** ftype,
+                [in, count=fnum] size_t* ftype_lengths,
                 int with_stats,
                 [in, string] const char* format,
                 [out] bst_ulong* len,
                 [out] char*** out_models);
-
+        
         public int enclave_XGBoosterGetModelRaw(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [out] bst_ulong *out_len,
                 [out] char **out_dptr);
-
+        
         public int enclave_XGBoosterLoadModelFromBuffer(
-                BoosterHandle handle,
+                [in, string] char* handle,
                 [in, size=len] const void* buf,
                 bst_ulong len);
-
+        
         public int enclave_XGDMatrixFree(
-                DMatrixHandle handle);
-
+                [in, string] char* handle);
+        
         public int enclave_XGBoosterFree(
-                BoosterHandle handle);
-
+                [in, string] char* handle);
+        
         public int enclave_get_remote_report_with_pubkey(
                 [out] uint8_t **pem_key, 
                 [out] size_t *key_size,
                 [out] uint8_t **remote_report,
                 [out] size_t  *remote_report_size);
-
+        
         public int enclave_verify_remote_report_and_set_pubkey(
                 [in, count=key_size] uint8_t *pem_key, 
                 size_t key_size,
                 [in, count=remote_report_size] uint8_t *remote_report,
                 size_t remote_report_size);
-
+        
         public int enclave_add_client_key(
                 [in, size=data_len] uint8_t* data, 
                 size_t data_len, 
                 [in, size=sig_len] uint8_t* signature,
                 size_t sig_len);
-
+        
         public void enclave_RabitInit(
                 int argc,
                 [user_check] char **argv);
-
+        
         public void enclave_RabitFinalize();
-
+        
         public int enclave_RabitGetRank();
-
+        
         public int enclave_RabitIsDistributed();
-
+        
         public void enclave_RabitTrackerPrint(
                 [user_check] const char *msg);
     };

--- a/enclave/xgboost.edl
+++ b/enclave/xgboost.edl
@@ -170,7 +170,7 @@ enclave {
         public int enclave_verify_remote_report_and_set_pubkey(
                 [in, count=key_size] uint8_t *pem_key, 
                 size_t key_size,
-                [in, count=remote_report_size] uint8_t *remote_report,
+                [in, size=remote_report_size] uint8_t *remote_report,
                 size_t remote_report_size);
         
         public int enclave_add_client_key(
@@ -181,7 +181,8 @@ enclave {
         
         public void enclave_RabitInit(
                 int argc,
-                [user_check] char **argv);
+                [in, count=argc] char **argv,
+                [in, count=argc] size_t* arg_lengths);
         
         public void enclave_RabitFinalize();
         

--- a/enclave/xgboost.edl
+++ b/enclave/xgboost.edl
@@ -191,7 +191,7 @@ enclave {
         public int enclave_RabitIsDistributed();
         
         public void enclave_RabitTrackerPrint(
-                [user_check] const char *msg);
+                [in, string] const char *msg);
     };
 };
 

--- a/host/src/c_api/c_api.cc
+++ b/host/src/c_api/c_api.cc
@@ -877,7 +877,11 @@ XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity) {
 XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
                     xgboost::bst_ulong len,
                     BoosterHandle *out) {
-    safe_ecall(enclave_XGBoosterCreate(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, dmats, len, out));
+  size_t handle_lengths[len];
+  for (int i = 0; i < len; i++) {
+    handle_lengths[i] = strlen(dmats[i]);
+  }
+  safe_ecall(enclave_XGBoosterCreate(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, const_cast<char**>(dmats), handle_lengths, len, out));
 }
 
 XGB_DLL int XGBoosterFree(BoosterHandle handle) {
@@ -911,7 +915,13 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
                                  const char* evnames[],
                                  xgboost::bst_ulong len,
                                  const char** out_str) {
-    safe_ecall(enclave_XGBoosterEvalOneIter(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, iter, dmats, evnames, len, (char**) out_str));
+  size_t handle_lengths[len];
+  size_t name_lengths[len];
+  for (int i = 0; i < len; i++) {
+    handle_lengths[i] = strlen(dmats[i]);
+    name_lengths[i] = strlen(evnames[i]);
+  }
+  safe_ecall(enclave_XGBoosterEvalOneIter(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, iter, dmats, handle_lengths, evnames, name_lengths, len, (char**) out_str));
 }
 
 XGB_DLL int XGBoosterPredict(BoosterHandle handle,
@@ -989,7 +999,13 @@ XGB_DLL int XGBoosterDumpModelWithFeatures(BoosterHandle handle,
                                    int with_stats,
                                    xgboost::bst_ulong* len,
                                    const char*** out_models) {
-   safe_ecall(enclave_XGBoosterDumpModelWithFeatures(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, (unsigned int) fnum, fname, ftype, with_stats, len, (char***) out_models));
+  size_t fname_lengths[fnum];
+  size_t ftype_lengths[fnum];
+  for (int i = 0; i < fnum; i++) {
+    fname_lengths[i] = strlen(fname[i]);
+    ftype_lengths[i] = strlen(ftype[i]);
+  }
+  safe_ecall(enclave_XGBoosterDumpModelWithFeatures(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, (unsigned int) fnum, fname, fname_lengths, ftype, ftype_lengths, with_stats, len, (char***) out_models));
 }
 
 XGB_DLL int XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
@@ -1000,7 +1016,13 @@ XGB_DLL int XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
                                    const char *format,
                                    xgboost::bst_ulong* len,
                                    const char*** out_models) {
-  safe_ecall(enclave_XGBoosterDumpModelExWithFeatures(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, (unsigned int) fnum, fname, ftype, with_stats, format, len, (char***) out_models));
+  size_t fname_lengths[fnum];
+  size_t ftype_lengths[fnum];
+  for (int i = 0; i < fnum; i++) {
+    fname_lengths[i] = strlen(fname[i]);
+    ftype_lengths[i] = strlen(ftype[i]);
+  }
+  safe_ecall(enclave_XGBoosterDumpModelExWithFeatures(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, (unsigned int) fnum, fname, fname_lengths, ftype, ftype_lengths, with_stats, format, len, (char***) out_models));
 }
 
 XGB_DLL int XGBoosterGetAttr(BoosterHandle handle,

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -35,15 +35,6 @@ if (result != OE_OK) {                                    \
 }                                                         \
 }
 
-#define check_enclave_ptr(ptr) {                          \
-if (!oe_is_within_enclave((ptr), sizeof((ptr)))) {        \
-  fprintf(stderr,                                         \
-      "%s:%d: Ptr bounds check faileds\n",                \
-      __FILE__, __LINE__);                                \
-  exit(1);                                                \
-}                                                         \
-}
-
 #define check_enclave_buffer(ptr, size) {                 \
 if (!oe_is_within_enclave((ptr), size)) {                 \
     fprintf(stderr,                                       \
@@ -72,10 +63,17 @@ typedef float bst_float;  // NOLINT(*)
 //#endif
 
 
+#ifdef __SGX__
+/*! \brief handle to DMatrix */
+typedef char* DMatrixHandle;  // NOLINT(*)
+/*! \brief handle to Booster */
+typedef char* BoosterHandle;  // NOLINT(*)
+#else
 /*! \brief handle to DMatrix */
 typedef void *DMatrixHandle;  // NOLINT(*)
 /*! \brief handle to Booster */
 typedef void *BoosterHandle;  // NOLINT(*)
+#endif
 /*! \brief handle to a data iterator */
 typedef void *DataIterHandle;  // NOLINT(*)
 /*! \brief handle to a internal data holder. */

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -429,7 +429,7 @@ class DMatrix(object):
                           DeprecationWarning)
 
         if isinstance(data, STRING_TYPES):
-            handle = ctypes.c_void_p()
+            handle = ctypes.c_char_p()
             if encrypted:
                 _check_call(_LIB.XGDMatrixCreateFromEncryptedFile(c_str(data),
                     ctypes.c_int(silent),
@@ -475,7 +475,7 @@ class DMatrix(object):
         """
         if len(csr.indices) != len(csr.data):
             raise ValueError('length mismatch: {} vs {}'.format(len(csr.indices), len(csr.data)))
-        handle = ctypes.c_void_p()
+        handle = ctypes.c_char_p()
         _check_call(_LIB.XGDMatrixCreateFromCSREx(c_array(ctypes.c_size_t, csr.indptr),
                                                   c_array(ctypes.c_uint, csr.indices),
                                                   c_array(ctypes.c_float, csr.data),
@@ -491,7 +491,7 @@ class DMatrix(object):
         """
         if len(csc.indices) != len(csc.data):
             raise ValueError('length mismatch: {} vs {}'.format(len(csc.indices), len(csc.data)))
-        handle = ctypes.c_void_p()
+        handle = ctypes.c_char_p()
         _check_call(_LIB.XGDMatrixCreateFromCSCEx(c_array(ctypes.c_size_t, csc.indptr),
                                                   c_array(ctypes.c_uint, csc.indices),
                                                   c_array(ctypes.c_float, csc.data),
@@ -519,7 +519,7 @@ class DMatrix(object):
         # we try to avoid data copies if possible (reshape returns a view when possible
         # and we explicitly tell np.array to try and avoid copying)
         data = np.array(mat.reshape(mat.size), copy=False, dtype=np.float32)
-        handle = ctypes.c_void_p()
+        handle = ctypes.c_char_p()
         missing = missing if missing is not None else np.nan
         if nthread is None:
             _check_call(_LIB.XGDMatrixCreateFromMat(
@@ -560,7 +560,7 @@ class DMatrix(object):
         for icol in range(data.ncols):
             feature_type_strings[icol] = ctypes.c_char_p(data.stypes[icol].name.encode('utf-8'))
 
-        handle = ctypes.c_void_p()
+        handle = ctypes.c_char_p()
         _check_call(_LIB.XGDMatrixCreateFromDT(
             ptrs, feature_type_strings,
             c_bst_ulong(data.shape[0]),
@@ -854,7 +854,7 @@ class DMatrix(object):
         #  """
         #  res = DMatrix(None, feature_names=self.feature_names,
                       #  feature_types=self.feature_types)
-        #  res.handle = ctypes.c_void_p()
+        #  res.handle = ctypes.c_char_p()
         #  _check_call(_LIB.XGDMatrixSliceDMatrix(self.handle,
                                                #  c_array(ctypes.c_int, rindex),
                                                #  c_bst_ulong(len(rindex)),
@@ -1233,8 +1233,8 @@ class Booster(object):
             if not isinstance(d, DMatrix):
                 raise TypeError('invalid cache item: {}'.format(type(d).__name__))
             self._validate_features(d)
-        dmats = c_array(ctypes.c_void_p, [d.handle for d in cache])
-        self.handle = ctypes.c_void_p()
+        dmats = c_array(ctypes.c_char_p, [d.handle for d in cache])
+        self.handle = ctypes.c_char_p()
 
         _check_call(_LIB.XGBoosterCreate(dmats, c_bst_ulong(len(cache)),
                                          ctypes.byref(self.handle)))
@@ -1267,8 +1267,8 @@ class Booster(object):
         handle = state['handle']
         if handle is not None:
             buf = handle
-            dmats = c_array(ctypes.c_void_p, [])
-            handle = ctypes.c_void_p()
+            dmats = c_array(ctypes.c_char_p, [])
+            handle = ctypes.c_char_p()
             _check_call(_LIB.XGBoosterCreate(dmats, c_bst_ulong(0), ctypes.byref(handle)))
             length = c_bst_ulong(len(buf))
             ptr = (ctypes.c_char * len(buf)).from_buffer(buf)
@@ -1458,7 +1458,7 @@ class Booster(object):
                 raise TypeError('expected string, got {}'.format(type(d[1]).__name__))
             self._validate_features(d[0])
 
-        dmats = c_array(ctypes.c_void_p, [d[0].handle for d in evals])
+        dmats = c_array(ctypes.c_char_p, [d[0].handle for d in evals])
         evnames = c_array(ctypes.c_char_p, [c_str(d[1]) for d in evals])
         msg = ctypes.c_char_p()
         _check_call(_LIB.XGBoosterEvalOneIter(self.handle, ctypes.c_int(iteration),


### PR DESCRIPTION
This PR hardens the enclave/host interface in a couple of ways:

1. It prevents pointers to DMatrix and Booster objects within the enclave from being passed to the host application. Instead of passing pointers, it maintains a map within the enclave that associates a string alias with each object; and passes these aliases to the host application instead. This prevents the host from causing the enclave to perform unexpected operations on its own memory by manipulating the pointers.

2. For arrays of strings, it additionally passes a corresponding array of lengths to the enclave, so the enclave can validate the string buffer without having to compute its size. (We need to implement this validation ourselves because Open Enclave's Edger8r does not validate individual string buffers in an array.)
Size computation within the enclave, e.g. using `strlen` can leak information in case the string crosses the enclave boundary -- in this case, the `strlen` operation will continue reading bytes until it finds a 0x00 byte, potentially leaking the address of this byte via side-channels.

3. Also validates argument buffers during a couple of rabit ecalls (was pending).