### PR TITLE
Upgrade to Open Enclave v0.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ option(OBLIVIOUS
     "Enable oblivious training and inference" ON)
 option(USE_AVX2 
     "Use AVX2 instructions to speed up oblivious primitives" ON)
+option(LVI_MITIGATION
+    "Enable mitigations for LVI vulnerability" ON)
+set(LVI_MITIGATION_BINDIR "/opt/openenclave/lvi_mitigation_bin"
+    CACHE STRING "Path to LVI mitigation dependencies")
 
 # Generate conf file
 FILE(WRITE ${PROJECT_SOURCE_DIR}/enclave/xgboost.conf

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -33,6 +33,11 @@ int main() {
 " XGBOOST_BUILTIN_PREFETCH_PRESENT)
 
 set(OE_MIN_VERSION 0.8.2)
+if (LVI_MITIGATION)
+  # Configure the cmake to use customized compilation toolchain.
+  # This package has to be added before `project()`.
+  find_package(OpenEnclave-LVI-Mitigation ${OE_MIN_VERSION} CONFIG REQUIRED)
+endif()
 find_package(OpenEnclave ${OE_MIN_VERSION} CONFIG REQUIRED)
 
 # Check endianness
@@ -99,7 +104,14 @@ if(OBLIVIOUS)
   target_compile_definitions(xgboost_enclave PUBLIC -D__ENCLAVE_OBLIVIOUS__)
 endif(OBLIVIOUS)
 
-target_link_libraries(xgboost_enclave openenclave::oeenclave openenclave::oelibcxx openenclave::oehostfs openenclave::oehostsock openenclave::oehostresolver)
+if (LVI_MITIGATION)
+    # Helper to enable compiler options for LVI mitigation.
+    apply_lvi_mitigation(xgboost_enclave)
+    # Link against LVI-mitigated libraries.
+    target_link_libraries(xgboost_enclave openenclave::oeenclave-lvi-cfg openenclave::oelibcxx-lvi-cfg openenclave::oehostfs-lvi-cfg openenclave::oehostsock-lvi-cfg openenclave::oehostresolver-lvi-cfg)
+else()
+    target_link_libraries(xgboost_enclave openenclave::oeenclave openenclave::oelibcxx openenclave::oehostfs openenclave::oehostsock openenclave::oehostresolver)
+endif()
 
 # Sign enclave
 add_custom_command(OUTPUT xgboost_enclave.signed

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -32,7 +32,8 @@ int main() {
 }
 " XGBOOST_BUILTIN_PREFETCH_PRESENT)
 
-find_package(OpenEnclave CONFIG REQUIRED)
+set(OE_MIN_VERSION 0.8.2)
+find_package(OpenEnclave ${OE_MIN_VERSION} CONFIG REQUIRED)
 
 # Check endianness
 include(TestBigEndian)

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -64,7 +64,6 @@ target_include_directories(xgboost_enclave
 target_compile_options(xgboost_enclave
   PRIVATE
   -U_FORTIFY_SOURCE 
-  -fno-stack-protector
   -fno-strict-aliasing
   -D_GLIBCXX_USE_CXX11_ABI=0 
   -ftls-model=local-exec

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -47,24 +47,25 @@
 if [ ${TASK} == "cmake_test" ]; then
     set -e
 
+    CMAKE_COMMON_FLAGS='-DOE_DEBUG=1 -DSIMULATE=ON -DLVI_MITIGATION=OFF'
     # Build/test without obliviousness
     rm -rf build
     mkdir build && cd build
-    cmake .. -DOE_DEBUG=1 -DSIMULATE=ON -DOBLIVIOUS=OFF -DUSE_AVX2=OFF
+    cmake .. ${CMAKE_COMMON_FLAGS} -DOBLIVIOUS=OFF -DUSE_AVX2=OFF
     make -j4
     cd ..
     rm -rf build
 
     # Build/test with obliviousness, without AVX
     mkdir build && cd build
-    cmake .. -DOE_DEBUG=1 -DSIMULATE=ON -DOBLIVIOUS=ON -DUSE_AVX2=OFF
+    cmake .. ${CMAKE_COMMON_FLAGS} -DOBLIVIOUS=ON -DUSE_AVX2=OFF
     make -j4
     cd ..
     rm -rf build
 
     # Build/test with obliviousness and AVX
     mkdir build && cd build
-    cmake .. -DOE_DEBUG=1 -DSIMULATE=ON -DOBLIVIOUS=ON -DUSE_AVX2=ON
+    cmake .. ${CMAKE_COMMON_FLAGS} -DOBLIVIOUS=ON -DUSE_AVX2=ON
     make -j4
     cd ..
     rm -rf build


### PR DESCRIPTION
Open Enclave v0.8.2 adds a couple of security improvements, incorporated in this PR:
1. Stack protection
2. LVI vulnerability mitigation