### PR TITLE
Enable backtrace for enclave errors

### DIFF
--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -85,6 +85,7 @@ target_compile_definitions(xgboost_enclave
   PRIVATE
   -D__SGX__
   -D__ENCLAVE__
+  -DDMLC_CORE_USE_CMAKE
   OE_API_VERSION=2
   -DDMLC_LOG_CUSTOMIZE=1  # enable custom logging
   ${XGBOOST_DEFINITIONS})

--- a/enclave/rabit/src/ssl_socket.h
+++ b/enclave/rabit/src/ssl_socket.h
@@ -23,8 +23,7 @@ static void print_err(int error_code) {
   const size_t LEN = 2048;
   char err_buf[LEN];
   mbedtls_strerror(error_code, err_buf, LEN);
-  mbedtls_printf(" ERROR %d: %s\n", getpid(), err_buf);
-  exit(1);
+  LOG(FATAL) << err_buf;
 }
 
 #define DEBUG_LEVEL 0

--- a/enclave/src/c_api/c_api_error.cc
+++ b/enclave/src/c_api/c_api_error.cc
@@ -3,8 +3,10 @@
  * \file c_api_error.cc
  * \brief C error handling
  */
-#include <dmlc/thread_local.h>
 #include <xgboost/c_api/c_api_error.h>
+
+#if false  // FIXME: Should we enable this within enclave?
+#include <dmlc/thread_local.h>
 
 struct XGBAPIErrorEntry {
   std::string last_error;
@@ -19,3 +21,14 @@ const char *XGBGetLastError() {
 void XGBAPISetLastError(const char* msg) {
   XGBAPIErrorStore::Get()->last_error = msg;
 }
+#else 
+// Enclave thread locals get erased on an enclave exit
+// So we save the error message at the host instead
+#include "xgboost_t.h"
+
+void XGBAPISetLastError(const char* msg) {
+  // FIXME: safe ocall
+  host_XGBAPISetLastError(msg);
+}
+
+#endif

--- a/enclave/xgboost.edl
+++ b/enclave/xgboost.edl
@@ -185,5 +185,9 @@ enclave {
         public void enclave_RabitTrackerPrint(
                 [user_check] const char *msg);
     };
+    untrusted {
+        void host_XGBAPISetLastError(
+                [in, string] const char* msg);
+    };
 };
 

--- a/host/src/c_api/c_api.cc
+++ b/host/src/c_api/c_api.cc
@@ -1405,8 +1405,8 @@ XGB_DLL int decrypt_dump(char* key, char** models, xgboost::bst_ulong length) {
           (const unsigned char*) key,     // encryption key
           CIPHER_KEY_SIZE * 8);           // key bits (must be 128, 192, or 256)
   if (ret != 0) {
-    printf( "mbedtls_gcm_setkey failed to set the key for AES cipher - returned -0x%04x\n", -ret );
-    exit(1);
+    //printf( "mbedtls_gcm_setkey failed to set the key for AES cipher - returned -0x%04x\n", -ret );
+    LOG(FATAL) << "mbedtls_gcm_setkey failed to set the key for AES cipher - returned " << -ret;
   }
 
   const char* total_encrypted;
@@ -1450,8 +1450,7 @@ XGB_DLL int decrypt_dump(char* key, char** models, xgboost::bst_ulong length) {
     decrypted[out_len] = '\0';
     free(ct);
     if (ret != 0) {
-      std::cout << "mbedtls_gcm_auth_decrypt failed with error " << -ret << std::endl;
-      exit(1);
+      LOG(FATAL) << "mbedtls_gcm_auth_decrypt failed with error " << -ret;
     }
     models[i] = (char*) decrypted;
   }
@@ -1488,8 +1487,8 @@ XGB_DLL int encrypt_file_with_keybuf(char* fname, char* e_fname, char* key) {
     int ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func, &entropy, (unsigned char *)pers.c_str(), pers.length() );
     if( ret != 0 )
     {
-        printf( "mbedtls_ctr_drbg_seed() failed - returned -0x%04x\n", -ret );
-        exit(1);
+        //printf( "mbedtls_ctr_drbg_seed() failed - returned -0x%04x\n", -ret );
+        LOG(FATAL) << "mbedtls_ctr_drbg_seed() failed - returned " << -ret;
     }
 
     // Initialize the GCM context with our key and desired cipher
@@ -1498,8 +1497,8 @@ XGB_DLL int encrypt_file_with_keybuf(char* fname, char* e_fname, char* key) {
             (unsigned char*) key,      // encryption key
             CIPHER_KEY_SIZE * 8);      // key bits (must be 128, 192, or 256)
     if( ret != 0 ) {
-        printf( "mbedtls_gcm_setkey failed to set the key for AES cipher - returned -0x%04x\n", -ret );
-        exit(1);
+        //printf( "mbedtls_gcm_setkey failed to set the key for AES cipher - returned -0x%04x\n", -ret );
+        LOG(FATAL) << "mbedtls_gcm_setkey failed to set the key for AES cipher - returned " << -ret;
     }
 
     std::ifstream infile(fname);
@@ -1546,8 +1545,8 @@ XGB_DLL int encrypt_file_with_keybuf(char* fname, char* e_fname, char* key) {
                 tag
                 );
         if( ret != 0 ) {
-            printf( "mbedtls_gcm_crypt_and_tag failed to encrypt the data - returned -0x%04x\n", -ret );
-            exit(1);
+            //printf( "mbedtls_gcm_crypt_and_tag failed to encrypt the data - returned -0x%04x\n", -ret );
+            LOG(FATAL) << "mbedtls_gcm_crypt_and_tag failed to encrypt the data - returned " << -ret;
         }
         std::string encoded = dmlc::data::base64_encode(iv, CIPHER_IV_SIZE);
         myfile 
@@ -1573,8 +1572,8 @@ XGB_DLL int decrypt_file_with_keybuf(char* fname, char* d_fname, char* key) {
             (const unsigned char*)key,      // encryption key
             CIPHER_KEY_SIZE * 8);           // key bits (must be 128, 192, or 256)
     if( ret != 0 ) {
-        printf( "mbedtls_gcm_setkey failed to set the key for AES cipher - returned -0x%04x\n", -ret );
-        exit(1);
+        //printf( "mbedtls_gcm_setkey failed to set the key for AES cipher - returned -0x%04x\n", -ret );
+        LOG(FATAL) << "mbedtls_gcm_setkey failed to set the key for AES cipher - returned " << -ret;
     }
 
     std::ifstream infile(fname);
@@ -1648,8 +1647,7 @@ XGB_DLL int decrypt_file_with_keybuf(char* fname, char* d_fname, char* key) {
         decrypted[out_len] = '\0';
         free(ct);
         if (ret != 0) {
-            std::cout << "mbedtls_gcm_auth_decrypt failed with error " << -ret << std::endl;
-            exit(1);
+            LOG(FATAL) << "mbedtls_gcm_auth_decrypt failed with error " << -ret;
         }
         myfile << decrypted << "\n";
     }

--- a/host/src/c_api/c_api_error.cc
+++ b/host/src/c_api/c_api_error.cc
@@ -5,6 +5,7 @@
  */
 #include <dmlc/thread_local.h>
 #include <xgboost/c_api/c_api_error.h>
+#include "xgboost_u.h"
 
 struct XGBAPIErrorEntry {
   std::string last_error;
@@ -18,4 +19,8 @@ const char *XGBGetLastError() {
 
 void XGBAPISetLastError(const char* msg) {
   XGBAPIErrorStore::Get()->last_error = msg;
+}
+
+void host_XGBAPISetLastError(const char* msg) {
+  XGBAPISetLastError(msg);
 }

--- a/include/dmlc/build_config_default.h
+++ b/include/dmlc/build_config_default.h
@@ -1,24 +1,36 @@
-#ifndef DMLC_BUILD_CONFIG_H_
-#define DMLC_BUILD_CONFIG_H_
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file build_config_default.h
+ * \brief Default detection logic for fopen64 and other symbols.
+ *        May be overriden by CMake
+ * \author KOLANICH
+ */
+#ifndef DMLC_BUILD_CONFIG_DEFAULT_H_
+#define DMLC_BUILD_CONFIG_DEFAULT_H_
 
-/* #undef DMLC_FOPEN_64_PRESENT */
-
-#if !defined(DMLC_FOPEN_64_PRESENT) && DMLC_USE_FOPEN64
+/* default logic for fopen64 */
+#if DMLC_USE_FOPEN64 && \
+  (!defined(__GNUC__) || (defined __ANDROID__) || (defined __FreeBSD__) \
+  || (defined __APPLE__) || ((defined __MINGW32__) && !(defined __MINGW64__)) \
+  || (defined __CYGWIN__) )
   #define DMLC_EMIT_FOPEN64_REDEFINE_WARNING
   #define fopen64 std::fopen
 #endif
 
-/* #undef DMLC_CXXABI_H_PRESENT */
-/* #undef DMLC_EXECINFO_H_PRESENT */
-
-#if (defined DMLC_CXXABI_H_PRESENT) && (defined DMLC_EXECINFO_H_PRESENT)
+/* default logic for stack trace */
+#if (defined(__GNUC__) && !defined(__MINGW32__)\
+     && !defined(__sun) && !defined(__SVR4)\
+     && !(defined __MINGW64__) && !(defined __ANDROID__))\
+     && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
+     && !defined(__RISCV__) && !defined(__hexagon__)
   #define DMLC_LOG_STACK_TRACE 1
   #define DMLC_LOG_STACK_TRACE_SIZE 10
-/* #undef DMLC_EXECINFO_H */
+  #define DMLC_EXECINFO_H <execinfo.h>
 #endif
 
-/* #undef DMLC_NANOSLEEP_PRESENT */
-
-#define DMLC_CMAKE_LITTLE_ENDIAN 1
+/* default logic for detecting existence of nanosleep() */
+#if !(defined _WIN32) || (defined __CYGWIN__)
+  #define DMLC_NANOSLEEP_PRESENT
+#endif
 
 #endif  // DMLC_BUILD_CONFIG_DEFAULT_H_

--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -16,7 +16,7 @@
 #include "./base.h"
 
 #if DMLC_LOG_STACK_TRACE
-#include <cxxabi.h>
+//#include <cxxabi.h>
 #include <sstream>
 #include DMLC_EXECINFO_H
 #endif
@@ -37,6 +37,7 @@ struct Error : public std::runtime_error {
 #if DMLC_LOG_STACK_TRACE
 inline std::string Demangle(char const *msg_str) {
   using std::string;
+#if false  // FIXME: Enable demangling
   string msg(msg_str);
   size_t symbol_start = string::npos;
   size_t symbol_end = string::npos;
@@ -57,6 +58,7 @@ inline std::string Demangle(char const *msg_str) {
       return os.str();
     }
   }
+#endif
   return string(msg_str);
 }
 


### PR DESCRIPTION
OE version 0.8 supports backtrace; this commit fixes LOG(FATAL) to capture a backtrace on an error, and write it out to a thread-local variable on the host via an ocall.
The ocall is required because thread-locals within enclaves are erased on an enclave exit; hence, retrieving the error message is no longer possible from the application.