### PR TITLE
Add get_rank back in

### DIFF
--- a/python-package/securexgboost/training.py
+++ b/python-package/securexgboost/training.py
@@ -55,7 +55,6 @@ def _train_internal(params, dtrain,
     #  start_iteration = int(version / 2)
     #  nboost += start_iteration
 
-    # FIXME: This code will only work for single node
     version = 0
     start_iteration = 0
     rank = rabit.get_rank()

--- a/python-package/securexgboost/training.py
+++ b/python-package/securexgboost/training.py
@@ -58,7 +58,7 @@ def _train_internal(params, dtrain,
     # FIXME: This code will only work for single node
     version = 0
     start_iteration = 0
-    rank = 0
+    rank = rabit.get_rank()
 
     callbacks_before_iter = [
         cb for cb in callbacks if cb.__dict__.get('before_iteration', False)]


### PR DESCRIPTION
The rank here only gets used with callback functions, but might as well enable proper retrieval of the rank since we already have support for it.