### PR TITLE
Fix readthedocs build

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
-sphinx
+sphinx==2.0.1
 mock
 guzzle_sphinx_theme
-breathe
+breathe>=4.12.0
 sh>=1.12.14
 matplotlib>=2.1
 graphviz

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.0.1
+sphinx>=3.0.1
 mock
 guzzle_sphinx_theme
 breathe>=4.12.0


### PR DESCRIPTION
The readthedocs build had been failing for about a week (beginning from [this commit](https://github.com/mc2-project/mc2-xgboost/commit/6eb5a13a9e742c5ddd3e9f5d9a46aa522129128b)) due to a version mismatch issue. This fixes the build.

I've tested the build by creating a new branch that readthedocs creates documentation from. [You can see that the documentation updates requiring Open Enclave 0.8.2 are now present.](https://mc2-xgboost.readthedocs.io/en/fix-docs/build.html#installing-the-open-enclave-sdk)