### PR TITLE
Fix remote report data mismatch

### DIFF
--- a/enclave/src/c_api/c_api.cc
+++ b/enclave/src/c_api/c_api.cc
@@ -317,9 +317,9 @@ int get_remote_report_with_pubkey_and_nonce(
 
 #else
   uint8_t report_data[CIPHER_PK_SIZE + CIPHER_IV_SIZE];
-  std::copy(public_key, public_key + CIPHER_PK_SIZE, report_data);
-  std::copy(enclave_nonce, enclave_nonce + CIPHER_IV_SIZE, report_data + CIPHER_PK_SIZE);
-  if (generate_remote_report(report_data, CIPHER_PK_SIZE + CIPHER_IV_SIZE + CIPHER_KEY_SIZE, &report, &report_size)) {
+  memcpy(report_data, public_key, CIPHER_PK_SIZE);
+  memcpy(report_data + CIPHER_PK_SIZE, enclave_nonce, CIPHER_IV_SIZE);
+  if (generate_remote_report(report_data, CIPHER_PK_SIZE + CIPHER_IV_SIZE, &report, &report_size)) {
     // Allocate memory on the host and copy the report over.
     *remote_report = (uint8_t*)oe_host_malloc(report_size);
     if (*remote_report == NULL) {

--- a/host/src/c_api/c_api.cc
+++ b/host/src/c_api/c_api.cc
@@ -1459,8 +1459,8 @@ XGB_DLL int verify_remote_report_and_set_pubkey_and_nonce(
   // Attest the remote report and accompanying key.
   size_t key_and_nonce_size = key_size + nonce_size;
   uint8_t key_and_nonce[key_and_nonce_size];
-  memcpy(key_and_nonce, pem_key, CIPHER_KEY_SIZE);
-  memcpy(key_and_nonce + CIPHER_KEY_SIZE, nonce, CIPHER_IV_SIZE);
+  memcpy(key_and_nonce, pem_key, CIPHER_PK_SIZE);
+  memcpy(key_and_nonce + CIPHER_PK_SIZE, nonce, CIPHER_IV_SIZE);
   if (!attest_remote_report(remote_report, remote_report_size, key_and_nonce, key_and_nonce_size)) {
     std::cout << "verify_report_and_set_pubkey_and_nonce failed." << std::endl;
     return -1;


### PR DESCRIPTION
Fixes a bug: incorrect calculation of report data size, because of which remote attestation was failing.