### PR TITLE
Initialize client list at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ cmake_policy(SET CMP0022 NEW)
 option(JVM_BINDINGS "Build JVM bindings" OFF)
 
 # Build options
-set(CLIENT_LIST user1 user2
-    CACHE STRING "List of usernames of clients in federation")
 set(SIGNER_PUB_FILE config/enclave_signer.pub
     CACHE STRING "Public key of enclave signing authority")
 set(SIGNER_KEY_FILE config/enclave_signer.pem
@@ -76,17 +74,7 @@ foreach(line IN LISTS CA_CERT_LINES)
     set(CA_CERT "${CA_CERT}\"${line}\\n\"\n")
 endforeach()
 
-# List of usernames of participating clients
-set(CLIENT_NAMES "")
-message("\nAuthorized client names:")
-foreach(name ${CLIENT_LIST})
-    message(${name})
-    set(CLIENT_NAMES "${CLIENT_NAMES} \"${name}\",")
-endforeach(name)
-set(CLIENT_NAMES "{${CLIENT_NAMES}}")
-list(LENGTH CLIENT_LIST NUM_CLIENTS)
-
-# Generate file to hardcode usernames and keys into enclave
+# Generate file to hardcode signer public key and root CA into enclave
 message(STATUS "cmake/attestation.h.in -> ${PROJECT_SOURCE_DIR}/include/enclave/attestation.h")
 configure_file("cmake/attestation.h.in" "${PROJECT_SOURCE_DIR}/include/enclave/attestation.h")
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ xgb.init_client(user_name="user1",
 				sym_key_file="key.txt",
 				priv_key_file="config/user1.pem",
 				cert_file="config/user1.crt")
-xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed")
+xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed", usernames=["user1"])
 
 # Remote attestation to authenticate enclave
 # If running in simulation mode, pass in `verify=False` below

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ xgb.init_client(user_name="user1",
 				sym_key_file="key.txt",
 				priv_key_file="config/user1.pem",
 				cert_file="config/user1.crt")
-xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed", usernames=["user1"])
+xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed", client_list=["user1"])
 
 # Remote attestation to authenticate enclave
 # If running in simulation mode, pass in `verify=False` below

--- a/cmake/attestation.h.in
+++ b/cmake/attestation.h.in
@@ -6,7 +6,5 @@
 
 static const char MRSIGNER_PUBLIC_KEY[] = ${MRSIGNER_PUBLIC_KEY};
 static const char* CA_CERT = ${CA_CERT};
-static const int NUM_CLIENTS = ${NUM_CLIENTS};
-static const std::vector<std::string> CLIENT_NAMES = ${CLIENT_NAMES};
 
 #endif

--- a/demo/c-api/c-api-demo.cc
+++ b/demo/c-api/c-api-demo.cc
@@ -45,7 +45,8 @@ int main(int argc, char** argv) {
 
   std::cout << "Creating enclave\n";
   int log_verbosity = 1;
-  safe_xgboost(XGBCreateEnclave(argv[1], log_verbosity));
+  char* usernames[1] = {"user1"};
+  safe_xgboost(XGBCreateEnclave(argv[1], usernames, 1, log_verbosity));
   
   oe_result_t result;
   int ret = 1;
@@ -68,7 +69,7 @@ int main(int argc, char** argv) {
   safe_xgboost(get_remote_report_with_pubkey_and_nonce(&pem_key, &key_size, &nonce, &nonce_size, &remote_report, &remote_report_size));
   // NOTE: Verification will fail in simulation mode
   // Comment out this line for testing the code in simulation mode
-  safe_xgboost(verify_remote_report_and_set_pubkey_and_nonce(pem_key, key_size, nonce, nonce_size, remote_report, remote_report_size));
+  //safe_xgboost(verify_remote_report_and_set_pubkey_and_nonce(pem_key, key_size, nonce, nonce_size, remote_report, remote_report_size));
 
   uint8_t* encrypted_data = (uint8_t*) malloc(1024*sizeof(uint8_t));
   size_t encrypted_data_size = 1024;

--- a/demo/c-api/c-api-demo.cc
+++ b/demo/c-api/c-api-demo.cc
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
   safe_xgboost(get_remote_report_with_pubkey_and_nonce(&pem_key, &key_size, &nonce, &nonce_size, &remote_report, &remote_report_size));
   // NOTE: Verification will fail in simulation mode
   // Comment out this line for testing the code in simulation mode
-  //safe_xgboost(verify_remote_report_and_set_pubkey_and_nonce(pem_key, key_size, nonce, nonce_size, remote_report, remote_report_size));
+  safe_xgboost(verify_remote_report_and_set_pubkey_and_nonce(pem_key, key_size, nonce, nonce_size, remote_report, remote_report_size));
 
   uint8_t* encrypted_data = (uint8_t*) malloc(1024*sizeof(uint8_t));
   size_t encrypted_data_size = 1024;

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -11,7 +11,7 @@ cert_file = DIR + "/../../../config/user1.crt"
 
 print("Init user and enclave parameters")
 xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", log_verbosity=0)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1"], log_verbosity=0)
 
 # Remote Attestation
 print("Remote attestation")

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -11,7 +11,7 @@ cert_file = DIR + "/../../../config/user1.crt"
 
 print("Init user and enclave parameters")
 xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"], log_verbosity=3)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"], log_verbosity=0)
 
 # Remote Attestation
 print("Remote attestation")

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -11,7 +11,7 @@ cert_file = DIR + "/../../../config/user1.crt"
 
 print("Init user and enclave parameters")
 xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1"], log_verbosity=0)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"], log_verbosity=3)
 
 # Remote Attestation
 print("Remote attestation")

--- a/demo/python/distributed/distr-training.py
+++ b/demo/python/distributed/distr-training.py
@@ -10,7 +10,7 @@ CERT_FILE = HOME_DIR + "config/user1.crt"
 username = "user1"
 print("Creating enclave")
 xgb.init_client(user_name=username, sym_key_file=SYM_KEY_FILE, priv_key_file=PRIVATE_KEY_FILE, cert_file=CERT_FILE)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=[username])
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=[username])
 
 # Remote Attestation
 print("Remote attestation")

--- a/demo/python/distributed/distr-training.py
+++ b/demo/python/distributed/distr-training.py
@@ -10,7 +10,7 @@ CERT_FILE = HOME_DIR + "config/user1.crt"
 username = "user1"
 print("Creating enclave")
 xgb.init_client(user_name=username, sym_key_file=SYM_KEY_FILE, priv_key_file=PRIVATE_KEY_FILE, cert_file=CERT_FILE)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed")
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=[username])
 
 # Remote Attestation
 print("Remote attestation")

--- a/demo/python/jupyter/e2e-demo.ipynb
+++ b/demo/python/jupyter/e2e-demo.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xgb.init_server(enclave_image=HOME_DIR + \"build/enclave/xgboost_enclave.signed\")"
+    "xgb.init_server(enclave_image=HOME_DIR + \"build/enclave/xgboost_enclave.signed\", client_list=[username])"
    ]
   },
   {
@@ -260,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/demo/python/multiclient-cluster-remote-control/client1/client1.py
+++ b/demo/python/multiclient-cluster-remote-control/client1/client1.py
@@ -11,7 +11,7 @@ HOME_DIR = DIR + "/../../../../"
 username = "user1"
 
 def run(channel_addr, sym_key_file, priv_key_file, cert_file):
-    xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file, remote_addr=channel_addr)
+    xgb.init_client(user_name=username, client_list=[username, "user2"], sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file, remote_addr=channel_addr)
 
     xgb.rabit.init()
 

--- a/demo/python/multiclient-cluster-remote-control/client2/client2.py
+++ b/demo/python/multiclient-cluster-remote-control/client2/client2.py
@@ -10,7 +10,7 @@ HOME_DIR = DIR + "/../../../../"
 username = "user2"
 
 def run(channel_addr, sym_key_file, priv_key_file, cert_file):
-    xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file, remote_addr=channel_addr)
+    xgb.init_client(user_name=username, client_list=["user1", username], sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file, remote_addr=channel_addr)
 
     xgb.rabit.init()
 

--- a/demo/python/multiclient-cluster-remote-control/server/enclave_serve.py
+++ b/demo/python/multiclient-cluster-remote-control/server/enclave_serve.py
@@ -3,6 +3,6 @@ import os
 
 HOME_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../../../../"
 
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1", "user2"], log_verbosity=0)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1", "user2"], log_verbosity=0)
 print("Waiting for client...")
 xgb.serve(all_users=["user1", "user2"], port=50051)

--- a/demo/python/multiclient-cluster-remote-control/server/enclave_serve.py
+++ b/demo/python/multiclient-cluster-remote-control/server/enclave_serve.py
@@ -3,6 +3,6 @@ import os
 
 HOME_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../../../../"
 
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", log_verbosity=0)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1", "user2"], log_verbosity=0)
 print("Waiting for client...")
 xgb.serve(all_users=["user1", "user2"], port=50051)

--- a/demo/python/remote-control/server/enclave_serve.py
+++ b/demo/python/remote-control/server/enclave_serve.py
@@ -4,6 +4,6 @@ import os
 HOME_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../../../../"
 
 
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", log_verbosity=0)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1"], log_verbosity=0)
 print("Waiting for clients...")
 xgb.serve(all_users=["user1"], port=50051)

--- a/demo/python/remote-control/server/enclave_serve.py
+++ b/demo/python/remote-control/server/enclave_serve.py
@@ -4,6 +4,6 @@ import os
 HOME_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../../../../"
 
 
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1"], log_verbosity=0)
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"], log_verbosity=0)
 print("Waiting for clients...")
 xgb.serve(all_users=["user1"], port=50051)

--- a/doc/get_started.rst
+++ b/doc/get_started.rst
@@ -40,7 +40,7 @@ This demo runs the enclave server on the same machine as the client for simplici
                    sym_key_file="demo/data/key_zeros.txt",
                    priv_key_file="config/user1.pem",
                    cert_file="config/user1.crt")
-   xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed", usernames=["user1"])
+   xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed", client_list=["user1"])
    # Remote Attestation
    xgb.attest()
 

--- a/doc/get_started.rst
+++ b/doc/get_started.rst
@@ -40,7 +40,7 @@ This demo runs the enclave server on the same machine as the client for simplici
                    sym_key_file="demo/data/key_zeros.txt",
                    priv_key_file="config/user1.pem",
                    cert_file="config/user1.crt")
-   xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed")
+   xgb.init_server(enclave_image="build/enclave/xgboost_enclave.signed", usernames=["user1"])
    # Remote Attestation
    xgb.attest()
 

--- a/enclave/include/enclave_context.h
+++ b/enclave/include/enclave_context.h
@@ -89,6 +89,10 @@ class EnclaveContext {
       return num_clients;
     }
 
+    std::vector<std::string> get_clients() {
+      return client_names;
+    }
+
     uint8_t* get_public_key() {
       return m_public_key;
     }

--- a/enclave/include/enclave_context.h
+++ b/enclave/include/enclave_context.h
@@ -24,10 +24,9 @@
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/error.h"
 
+#include <rabit/rabit.h>
 
 class EnclaveContext {
-  // FIXME Embed root CA for clients
-
   private:
     mbedtls_ctr_drbg_context m_ctr_drbg_context;
     mbedtls_entropy_context m_entropy_context;
@@ -49,10 +48,9 @@ class EnclaveContext {
     int booster_ctr;
     int dmatrix_ctr;
 
-    // FIXME use array of fixed length instead of vector
-    //std::unordered_map<std::string, std::vector<uint8_t>> client_keys;
-    uint8_t client_key[CIPHER_KEY_SIZE];
-    bool client_key_is_set;
+    // list of usernames configured by the host at enclave launch
+    std::vector<std::string> client_names;
+    int num_clients;
 
     // map username to client_key
     std::unordered_map<std::string, std::vector<uint8_t>> client_keys;
@@ -65,9 +63,9 @@ class EnclaveContext {
       generate_nonce();
       m_nonce_ctr = 0;
       generate_symm_key();
-      client_key_is_set = false;
       booster_ctr = 0;
       dmatrix_ctr = 0;
+      num_clients = 0;
     }
 
   public:
@@ -80,6 +78,15 @@ class EnclaveContext {
     static EnclaveContext& getInstance() {
       static EnclaveContext instance;
       return instance;
+    }
+
+    void set_usernames(char** usernames, int len) {
+      client_names.assign(usernames, usernames + len);
+      num_clients = len;
+    }
+
+    int get_num_clients() {
+      return num_clients;
     }
 
     uint8_t* get_public_key() {
@@ -243,7 +250,7 @@ class EnclaveContext {
       int ret = 1;
 
       // FIXME: Currently we expect sigs to be in same order as users
-      for (auto _username: CLIENT_NAMES) {
+      for (auto _username: client_names) {
         char* username = (char*)_username.c_str();
 
         mbedtls_pk_init(&_pk_context);
@@ -254,7 +261,7 @@ class EnclaveContext {
           LOG(FATAL) << "verification failed - mbedtls_x509_crt_parse returned" << ret;
         }
         int i = -1;
-        for (int j = 0; j < NUM_CLIENTS; j++) {
+        for (int j = 0; j < num_clients; j++) {
           if (strcmp(signers[j], username) == 0) {
             i = j;
             break;
@@ -416,7 +423,7 @@ class EnclaveContext {
       std::string user_nam(nameptr, nameptr + name_len);
 
       // Verify client's identity
-      if (std::find(CLIENT_NAMES.begin(), CLIENT_NAMES.end(), user_nam) == CLIENT_NAMES.end()) {
+      if (std::find(client_names.begin(), client_names.end(), user_nam) == client_names.end()) {
         LOG(FATAL) << "No such authorized client";
       }
       client_keys[user_nam] = user_private_key;

--- a/enclave/src/c_api/c_api_mc.cc
+++ b/enclave/src/c_api/c_api_mc.cc
@@ -126,18 +126,20 @@ int get_remote_report_with_pubkey_and_nonce(
   std::vector<std::string> usernames_list = EnclaveContext::getInstance().get_clients();
   size_t total_len = 0;
   for (int i = 0; i < usernames_list.size(); i++) {
-    total_len += usernames_list[i].length + 1;
+    total_len += usernames_list[i].length() + 1;
   }
-  uint8_t report_data[CIPHER_PK_SIZE + CIPHER_IV_SIZE + total_len];
+  size_t report_data_size = CIPHER_PK_SIZE + CIPHER_IV_SIZE + total_len;
+  uint8_t report_data[report_data_size];
   memcpy(report_data, public_key, CIPHER_PK_SIZE);
   memcpy(report_data + CIPHER_PK_SIZE, enclave_nonce, CIPHER_IV_SIZE);
   uint8_t* ptr = report_data + CIPHER_PK_SIZE + CIPHER_IV_SIZE;
   for (int i = 0; i < usernames_list.size(); i++) {
-    size_t len = usernames_list[i].length + 1;
+    size_t len = usernames_list[i].length() + 1;
     memcpy(ptr, usernames_list[i].c_str(), len);
     ptr += len;
   }
-  if (generate_remote_report(report_data, CIPHER_PK_SIZE + CIPHER_IV_SIZE, &report, &report_size)) {
+
+  if (generate_remote_report(report_data, report_data_size, &report, &report_size)) {
     // Allocate memory on the host and copy the report over.
     *remote_report = (uint8_t*)oe_host_malloc(report_size);
     if (*remote_report == NULL) {

--- a/enclave/src/c_api/c_api_mc.cc
+++ b/enclave/src/c_api/c_api_mc.cc
@@ -123,9 +123,20 @@ int get_remote_report_with_pubkey_and_nonce(
   ret = 0;
 
 #else
-  uint8_t report_data[CIPHER_PK_SIZE + CIPHER_IV_SIZE];
+  std::vector<std::string> usernames_list = EnclaveContext::getInstance().get_clients();
+  size_t total_len = 0;
+  for (int i = 0; i < usernames_list.size(); i++) {
+    total_len += usernames_list[i].length + 1;
+  }
+  uint8_t report_data[CIPHER_PK_SIZE + CIPHER_IV_SIZE + total_len];
   memcpy(report_data, public_key, CIPHER_PK_SIZE);
   memcpy(report_data + CIPHER_PK_SIZE, enclave_nonce, CIPHER_IV_SIZE);
+  uint8_t* ptr = report_data + CIPHER_PK_SIZE + CIPHER_IV_SIZE;
+  for (int i = 0; i < usernames_list.size(); i++) {
+    size_t len = usernames_list[i].length + 1;
+    memcpy(ptr, usernames_list[i].c_str(), len);
+    ptr += len;
+  }
   if (generate_remote_report(report_data, CIPHER_PK_SIZE + CIPHER_IV_SIZE, &report, &report_size)) {
     // Allocate memory on the host and copy the report over.
     *remote_report = (uint8_t*)oe_host_malloc(report_size);
@@ -175,12 +186,6 @@ int get_remote_report_with_pubkey_and_nonce(
 #endif
   return ret;
 }
-
-//int add_client_key(uint8_t* data, size_t len, uint8_t* signature, size_t sig_len) {
-//    if (EnclaveContext::getInstance().decrypt_and_save_client_key(data, len, signature, sig_len))
-//      return 0;
-//    return -1;
-//}
 
 int add_client_key_with_certificate(char * cert,
         int cert_len,

--- a/enclave/xgboost.edl
+++ b/enclave/xgboost.edl
@@ -3,6 +3,9 @@ enclave {
     include "rabit/c_api.h"
     trusted {
         public void enclave_init(
+                [in, count=num_users] char **usernames,
+                [in, count=num_users] size_t* username_lengths,
+                size_t num_users,
                 int log_verbosity);
 
         public int enclave_XGDMatrixCreateFromFile(

--- a/enclave/xgboost_mc.edl
+++ b/enclave/xgboost_mc.edl
@@ -3,6 +3,9 @@ enclave {
     include "rabit/c_api.h"
     trusted {
         public void enclave_init(
+                [in, count=num_users] char **usernames,
+                [in, count=num_users] size_t* username_lengths,
+                size_t num_users,
                 int log_verbosity);
 
         public int enclave_XGDMatrixCreateFromFile(

--- a/host/src/c_api/c_api.cc
+++ b/host/src/c_api/c_api.cc
@@ -396,8 +396,11 @@ XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
 
 // xgboost implementation
 //
-XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity) {
+XGB_DLL int XGBCreateEnclave(const char *enclave_image, char** usernames, size_t num_clients, int log_verbosity) {
   if (!Enclave::getInstance().getEnclave()) {
+    size_t username_lengths[num_clients];
+    get_str_lengths(usernames, num_clients, username_lengths);
+
     oe_result_t result;
 
     uint32_t flags = 0;
@@ -421,7 +424,8 @@ XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity) {
       oe_terminate_enclave(Enclave::getInstance().getEnclave());
       return Enclave::getInstance().enclave_ret;
     }
-    safe_ecall(enclave_init(Enclave::getInstance().getEnclave(), log_verbosity));
+    Enclave::getInstance().set_num_clients(num_clients);
+    safe_ecall(enclave_init(Enclave::getInstance().getEnclave(), usernames, username_lengths, num_clients, log_verbosity));
   }
   return 0;
 }

--- a/host/src/c_api/c_api_mc.cc
+++ b/host/src/c_api/c_api_mc.cc
@@ -746,7 +746,7 @@ XGB_DLL int verify_remote_report_and_set_pubkey_and_nonce(
   // Attest the remote report and accompanying key.
   size_t total_len = 0;
   for (int i = 0; i < num_users; i++) {
-    total_len += strlen(usernames[i] + 1);
+    total_len += strlen(usernames[i]) + 1;
   }
   size_t report_data_size = key_size + nonce_size + total_len;
   uint8_t report_data[report_data_size];
@@ -754,10 +754,11 @@ XGB_DLL int verify_remote_report_and_set_pubkey_and_nonce(
   memcpy(report_data + CIPHER_PK_SIZE, nonce, CIPHER_IV_SIZE);
   uint8_t* ptr = report_data + CIPHER_PK_SIZE + CIPHER_IV_SIZE;
   for (int i = 0; i < num_users; i++) {
-    size_t len = strlen(usernames[i] + 1);
+    size_t len = strlen(usernames[i]) + 1;
     memcpy(ptr, usernames[i], len);
     ptr += len;
   }
+
   if (!attest_remote_report(remote_report, remote_report_size, report_data, report_data_size)) {
     std::cout << "verify_report_and_set_pubkey_and_nonce failed." << std::endl;
     return -1;

--- a/host/src/c_api/c_api_mc.cc
+++ b/host/src/c_api/c_api_mc.cc
@@ -107,6 +107,7 @@ int XGDMatrixCreateFromEncryptedFile(const char *fnames[],
                                      size_t* sig_lengths) {
     size_t fname_lengths[num_files];
     size_t username_lengths[num_files];
+    int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
     size_t signer_lengths[NUM_CLIENTS];
 
     get_str_lengths((char**)fnames, num_files, fname_lengths);
@@ -159,6 +160,7 @@ XGB_DLL int XGDMatrixNumRow(const DMatrixHandle handle,
                             char **signers,
                             uint8_t* signatures[],
                             size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -175,6 +177,7 @@ XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
                             char **signers,
                             uint8_t* signatures[],
                             size_t* sig_lengths) {                          
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -183,8 +186,11 @@ XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
 
 // xgboost implementation
 
-XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity) {
+XGB_DLL int XGBCreateEnclave(const char *enclave_image, char** usernames, size_t num_clients, int log_verbosity) {
   if (!Enclave::getInstance().getEnclave()) {
+    size_t username_lengths[num_clients];
+    get_str_lengths(usernames, num_clients, username_lengths);
+
     oe_result_t result;
 
     uint32_t flags = 0;
@@ -208,7 +214,8 @@ XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity) {
       oe_terminate_enclave(Enclave::getInstance().getEnclave());
       return Enclave::getInstance().enclave_ret;
     }
-    safe_ecall(enclave_init(Enclave::getInstance().getEnclave(), log_verbosity));
+    Enclave::getInstance().set_num_clients(num_clients);
+    safe_ecall(enclave_init(Enclave::getInstance().getEnclave(), usernames, username_lengths, num_clients, log_verbosity));
   }
   return 0;
 }
@@ -224,6 +231,7 @@ XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
                     char **signers,
                     uint8_t* signatures[],
                     size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t handle_lengths[len];
   size_t signer_lengths[NUM_CLIENTS];
 
@@ -248,6 +256,7 @@ XGB_DLL int XGBoosterSetParam(BoosterHandle handle,
                               char **signers,
                               uint8_t* signatures[],
                               size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -265,6 +274,7 @@ XGB_DLL int XGBoosterUpdateOneIter(BoosterHandle handle,
                                    char **signers,
                                    uint8_t* signatures[],
                                    size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -309,6 +319,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              char **signers,
                              uint8_t* signatures[],
                              size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -316,6 +327,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
 }
 
 XGB_DLL int XGBoosterLoadModel(BoosterHandle handle, const char* fname, uint8_t* nonce, size_t nonce_size, uint32_t nonce_ctr, uint8_t** out_sig, size_t* out_sig_length, char** signers, uint8_t* signatures[], size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -323,6 +335,7 @@ XGB_DLL int XGBoosterLoadModel(BoosterHandle handle, const char* fname, uint8_t*
 }
 
 XGB_DLL int XGBoosterSaveModel(BoosterHandle handle, const char* fname, uint8_t* nonce, size_t nonce_size, uint32_t nonce_ctr, uint8_t** out_sig, size_t* out_sig_length, char** signers, uint8_t* signatures[], size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -337,6 +350,7 @@ XGB_DLL int XGBoosterLoadModelFromBuffer(BoosterHandle handle,
                                          char** signers,
                                          uint8_t* signatures[],
                                          size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -354,6 +368,7 @@ XGB_DLL int XGBoosterGetModelRaw(BoosterHandle handle,
                                  char** signers,
                                  uint8_t* signatures[],
                                  size_t* sig_lengths) {
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -385,6 +400,7 @@ XGB_DLL int XGBoosterDumpModelEx(BoosterHandle handle,
                                  char** signers,
                                  uint8_t* signatures[],
                                  size_t* sig_lengths){
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   size_t signer_lengths[NUM_CLIENTS];
   get_str_lengths(signers, NUM_CLIENTS, signer_lengths);
 
@@ -414,6 +430,7 @@ XGB_DLL int XGBoosterDumpModelWithFeatures(BoosterHandle handle,
   get_str_lengths((char**)fname, fnum, fname_lengths);
   get_str_lengths((char**)ftype, fnum, ftype_lengths);
 
+  int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
   safe_ecall(enclave_XGBoosterDumpModelWithFeatures(Enclave::getInstance().getEnclave(), &Enclave::getInstance().enclave_ret, handle, (unsigned int) fnum, fname, fname_lengths, ftype, ftype_lengths, with_stats, nonce, nonce_size, nonce_ctr, len, (char***) out_models, out_sig, out_sig_length, signers, signer_lengths, signatures, sig_lengths, NUM_CLIENTS));
 }
 
@@ -435,6 +452,7 @@ XGB_DLL int XGBoosterDumpModelExWithFeatures(BoosterHandle handle,
                                              size_t* sig_lengths) {
     size_t fname_lengths[fnum];
     size_t ftype_lengths[fnum];
+    int NUM_CLIENTS = Enclave::getInstance().get_num_clients();
     size_t signer_lengths[NUM_CLIENTS];
 
     get_str_lengths((char**)fname, fnum, fname_lengths);

--- a/include/enclave/enclave.h
+++ b/include/enclave/enclave.h
@@ -9,6 +9,7 @@ class Enclave {
     private:
         // Private constructor to prevent instancing
         Enclave() {}
+        int num_clients;
 
     public:
         // Don't forget to declare these two. You want to make sure they
@@ -31,6 +32,14 @@ class Enclave {
 
         oe_enclave_t** getEnclaveRef() {
             return &(this->enclave_ref);
+        }
+
+        int set_num_clients(int num) {
+          num_clients = num;
+        }
+
+        int get_num_clients() {
+          return num_clients;
         }
 
 };

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -102,7 +102,7 @@ XGB_DLL const char *XGBGetLastError(void);
 XGB_DLL int XGBRegisterLogCallback(void (*callback)(const char*));
 
 #if defined(__HOST__)
-XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity);
+XGB_DLL int XGBCreateEnclave(const char *enclave_image, char** usernames, size_t num_clients, int log_verbosity);
 #endif
 
 /*!

--- a/include/xgboost/c_api_mc.h
+++ b/include/xgboost/c_api_mc.h
@@ -1026,6 +1026,8 @@ XGB_DLL int verify_remote_report_and_set_pubkey_and_nonce(
     size_t pem_key_size,
     uint8_t* nonce,
     size_t nonce_size,
+    char** usernames,
+    size_t num_users,
     uint8_t* remote_report,
     size_t remote_report_size);
 

--- a/include/xgboost/c_api_mc.h
+++ b/include/xgboost/c_api_mc.h
@@ -100,7 +100,7 @@ XGB_DLL const char *XGBGetLastError(void);
 XGB_DLL int XGBRegisterLogCallback(void (*callback)(const char*));
 
 #if defined(__HOST__)
-XGB_DLL int XGBCreateEnclave(const char *enclave_image, int log_verbosity);
+XGB_DLL int XGBCreateEnclave(const char *enclave_image, char** usernames, size_t num_clients, int log_verbosity);
 #endif
 
 /*!

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -2520,7 +2520,7 @@ def init_client(remote_addr=None, user_name=None,
     _CONF["nonce_ctr"] = 0 
 
 
-def init_server(enclave_image=None, log_verbosity=0):
+def init_server(enclave_image=None, usernames=[], log_verbosity=0):
     """
     Launch the enclave from an image. This API should be invoked only by the servers and not the clients.
 
@@ -2528,10 +2528,12 @@ def init_server(enclave_image=None, log_verbosity=0):
     ----------
     enclave_image: str
         Path to enclave binary
+    usernames: list
+        List of client usernames (strings) allowed to use the enclaves
     log_verbosity: int, optional
         Verbosity level for enclave (for enclaves in debug mode)
     """
-    _check_call(_LIB.XGBCreateEnclave(c_str(enclave_image), log_verbosity))
+    _check_call(_LIB.XGBCreateEnclave(c_str(enclave_image), from_pystr_to_cstr(usernames), len(usernames), log_verbosity))
 
 
 def attest(verify=True):

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -2584,12 +2584,12 @@ def attest(verify=True):
             ctypes.byref(nonce), ctypes.byref(nonce_size),
             ctypes.byref(remote_report), ctypes.byref(remote_report_size)))
 
-        # Verify attestation report
+    # Verify attestation report
     if (verify):
         _check_call(_LIB.verify_remote_report_and_set_pubkey_and_nonce(
             pem_key, pem_key_size,
             nonce, nonce_size,
-            from_pystr_to_cstr(_CONF["client_names"]),
+            from_pystr_to_cstr(_CONF["client_names"]), len(_CONF["client_names"]),
             remote_report, remote_report_size))
 
     _CONF["enclave_pk"] = pem_key

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -2507,7 +2507,7 @@ def init_client(remote_addr=None, user_name=None, client_list=[],
     _CONF["current_user"] = user_name
     _clients = set(client_list)
     _clients.add(user_name)
-    _CONF["client_names"] = list(_clients)
+    _CONF["client_list"] = list(_clients)
 
     if sym_key_file is not None:
         with open(sym_key_file, "rb") as keyfile:
@@ -2525,7 +2525,7 @@ def init_client(remote_addr=None, user_name=None, client_list=[],
     _CONF["nonce_ctr"] = 0 
 
 
-def init_server(enclave_image=None, usernames=[], log_verbosity=0):
+def init_server(enclave_image=None, client_list=[], log_verbosity=0):
     """
     Launch the enclave from an image. This API should be invoked only by the servers and not the clients.
 
@@ -2533,12 +2533,12 @@ def init_server(enclave_image=None, usernames=[], log_verbosity=0):
     ----------
     enclave_image: str
         Path to enclave binary
-    usernames: list
+    client_list: list
         List of client usernames (strings) allowed to use the enclaves
     log_verbosity: int, optional
         Verbosity level for enclave (for enclaves in debug mode)
     """
-    _check_call(_LIB.XGBCreateEnclave(c_str(enclave_image), from_pystr_to_cstr(usernames), len(usernames), log_verbosity))
+    _check_call(_LIB.XGBCreateEnclave(c_str(enclave_image), from_pystr_to_cstr(client_list), len(client_list), log_verbosity))
 
 
 def attest(verify=True):
@@ -2589,7 +2589,7 @@ def attest(verify=True):
         _check_call(_LIB.verify_remote_report_and_set_pubkey_and_nonce(
             pem_key, pem_key_size,
             nonce, nonce_size,
-            from_pystr_to_cstr(_CONF["client_names"]), len(_CONF["client_names"]),
+            from_pystr_to_cstr(_CONF["client_list"]), len(_CONF["client_list"]),
             remote_report, remote_report_size))
 
     _CONF["enclave_pk"] = pem_key

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -2534,7 +2534,7 @@ def init_server(enclave_image=None, client_list=[], log_verbosity=0):
     enclave_image: str
         Path to enclave binary
     client_list: list
-        List of client usernames (strings) allowed to use the enclaves
+        List of usernames (strings) of clients in the collaboration allowed to use the enclaves
     log_verbosity: int, optional
         Verbosity level for enclave (for enclaves in debug mode)
     """

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -2481,7 +2481,7 @@ class Booster(object):
 # Enclave init and attestation APIs
 ##########################################
 
-def init_client(remote_addr=None, user_name=None, 
+def init_client(remote_addr=None, user_name=None, client_list=[],
         sym_key_file=None, priv_key_file=None, cert_file=None):
     """
     Initialize the client. Set up the client's keys, and specify the IP address of the enclave server.
@@ -2491,7 +2491,9 @@ def init_client(remote_addr=None, user_name=None,
     remote_addr: str
         IP address of remote server running the enclave
     user_name : str
-        Current user's identity
+        Current user's username
+    client_list : list
+        List of usernames for all clients in the collaboration
     sym_key_file : str
         Path to file containing user's symmetric key used for encrypting data
     priv_key_file : str
@@ -2503,6 +2505,9 @@ def init_client(remote_addr=None, user_name=None,
 
     _CONF["remote_addr"] = remote_addr;
     _CONF["current_user"] = user_name
+    _clients = set(client_list)
+    _clients.add(user_name)
+    _CONF["client_names"] = list(_clients)
 
     if sym_key_file is not None:
         with open(sym_key_file, "rb") as keyfile:
@@ -2584,6 +2589,7 @@ def attest(verify=True):
         _check_call(_LIB.verify_remote_report_and_set_pubkey_and_nonce(
             pem_key, pem_key_size,
             nonce, nonce_size,
+            from_pystr_to_cstr(_CONF["client_names"]),
             remote_report, remote_report_size))
 
     _CONF["enclave_pk"] = pem_key

--- a/tests/python/config.py
+++ b/tests/python/config.py
@@ -8,5 +8,5 @@ priv_key_file = HOME_DIR + "config/user1.pem"
 cert_file = HOME_DIR + "config/user1.crt"
 
 xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed")
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=[username])
 xgb.attest(verify=False)

--- a/tests/python/config.py
+++ b/tests/python/config.py
@@ -8,5 +8,5 @@ priv_key_file = HOME_DIR + "config/user1.pem"
 cert_file = HOME_DIR + "config/user1.crt"
 
 xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file)
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=[username])
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=[username])
 xgb.attest(verify=False)

--- a/tests/rpc/start_enclave.py
+++ b/tests/rpc/start_enclave.py
@@ -3,7 +3,7 @@ import os
 
 HOME_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../../"
 
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed")
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1"])
 
 # Start RPC server
 xgb.serve(all_users=["user1"], port=50051)

--- a/tests/rpc/start_enclave.py
+++ b/tests/rpc/start_enclave.py
@@ -3,7 +3,7 @@ import os
 
 HOME_DIR = os.path.dirname(os.path.realpath(__file__)) + "/../../"
 
-xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", usernames=["user1"])
+xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"])
 
 # Start RPC server
 xgb.serve(all_users=["user1"], port=50051)


### PR DESCRIPTION
Currently the code requires the list of clients to be hardcoded into the enclave at build time, which requires the code to be rebuilt across the different tutorials. This PR allows the server to initialize the client list at runtime instead (in `init_server`). Clients verify the list during attestation.