### PR TITLE
Read client parameters from configuration file

### DIFF
--- a/demo/python/basic/config
+++ b/demo/python/basic/config
@@ -1,6 +1,0 @@
-[default]
-user_name = user1
-sym_key_file =  ../../data/key_zeros.txt
-priv_key_file = ../../../config/user1.pem
-cert_file = ../../../config/user1.crt
-

--- a/demo/python/basic/config
+++ b/demo/python/basic/config
@@ -1,0 +1,6 @@
+[default]
+user_name = user1
+sym_key_file =  ../../data/key_zeros.txt
+priv_key_file = ../../../config/user1.pem
+cert_file = ../../../config/user1.crt
+

--- a/demo/python/basic/config.ini
+++ b/demo/python/basic/config.ini
@@ -1,0 +1,10 @@
+[default]
+#Current user's username
+user_name = user1
+#Path to file containing user's symmetric key used for encrypting data
+sym_key_file =  ../../data/key_zeros.txt
+#Path to file containing user's private key used for signing data
+priv_key_file = ../../../config/user1.pem
+#Path to file containing user's public key certificate
+cert_file = ../../../config/user1.crt
+

--- a/demo/python/basic/config.ini
+++ b/demo/python/basic/config.ini
@@ -1,10 +1,14 @@
 [default]
+
 #Current user's username
 user_name = user1
+
 #Path to file containing user's symmetric key used for encrypting data
 sym_key_file =  ../../data/key_zeros.txt
+
 #Path to file containing user's private key used for signing data
 priv_key_file = ../../../config/user1.pem
+
 #Path to file containing user's public key certificate
 cert_file = ../../../config/user1.crt
 

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -6,7 +6,7 @@ DIR = os.path.dirname(os.path.realpath(__file__))
 HOME_DIR = DIR + "/../../../"
 
 print("Init user and enclave parameters")
-xgb.init_client(config="config")
+xgb.init_client(config="config.ini")
 xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"], log_verbosity=0)
 
 # Remote Attestation

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -14,7 +14,7 @@ print("Remote attestation")
 
 # Note: Simulation mode does not support attestation
 # pass in `verify=False` to attest()
-xgb.attest(verify=False)
+xgb.attest()
 
 print("Creating training matrix from encrypted file")
 dtrain = xgb.DMatrix({username: HOME_DIR + "demo/data/agaricus.txt.train.enc"})

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -14,7 +14,7 @@ print("Remote attestation")
 
 # Note: Simulation mode does not support attestation
 # pass in `verify=False` to attest()
-xgb.attest()
+xgb.attest(verify=False)
 
 print("Creating training matrix from encrypted file")
 dtrain = xgb.DMatrix({username: HOME_DIR + "demo/data/agaricus.txt.train.enc"})

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -4,13 +4,9 @@ import os
 username = "user1"
 DIR = os.path.dirname(os.path.realpath(__file__))
 HOME_DIR = DIR + "/../../../"
-sym_key_file = DIR + "/../../data/key_zeros.txt"
-priv_key_file = DIR + "/../../../config/user1.pem"
-cert_file = DIR + "/../../../config/user1.crt"
-
 
 print("Init user and enclave parameters")
-xgb.init_client(user_name=username, sym_key_file=sym_key_file, priv_key_file=priv_key_file, cert_file=cert_file)
+xgb.init_client(config="config")
 xgb.init_server(enclave_image=HOME_DIR + "build/enclave/xgboost_enclave.signed", client_list=["user1"], log_verbosity=0)
 
 # Remote Attestation

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -15,6 +15,7 @@ import os
 import re
 import sys
 import warnings
+import configparser
 
 import grpc
 from .rpc import remote_pb2
@@ -2481,13 +2482,80 @@ class Booster(object):
 # Enclave init and attestation APIs
 ##########################################
 
-def init_client(remote_addr=None, user_name=None, client_list=[],
+def init_config(config):
+    """
+    Initialize the client. Set up the client's keys, and specify the IP address of the enclave server.
+
+    Parameters
+    ----------
+    config: file
+        Configuration file containing the following parameters:
+        remote_addr: IP address of remote server running the enclave
+        user_name : Current user's username
+        client_list : List of usernames for all clients in the collaboration
+        sym_key_file : Path to file containing user's symmetric key used for encrypting data
+        priv_key_file : Path to file containing user's private key used for signing data
+        cert_file : Path to file containing user's public key certificate
+    """
+    conf = configparser.ConfigParser()
+    conf.read(config)
+    if len(conf) == 0:
+        raise ValueError("Failed to open config file")
+
+    # TODO(rishabh): Verify parameters
+
+    try:
+        if conf.has_option('default','remote_addr'):
+            _CONF["remote_addr"] = conf['default']['remote_addr']
+        else:
+            _CONF["remote_addr"] = None
+
+        user_name = conf['default']['user_name']
+        _CONF["current_user"] = user_name
+
+        if conf.has_option('default','client_list'):
+            client_list = conf['default']['client_list'].split(',')
+        else:
+            client_list = []
+        for i, s in enumerate(client_list):
+            client_list[i] = s.strip()
+        client_set = set(client_list)
+        client_set.add(user_name)
+        _CONF["client_list"] = list(sorted(client_set))
+
+        sym_key_file = conf['default']['sym_key_file']
+        print(os.getcwd())
+        if sym_key_file is not None:
+            with open(sym_key_file, "rb") as keyfile:
+                _CONF["current_user_sym_key"] = keyfile.read()
+                # TODO(rishabh): Save buffer instead of file
+                # with open(priv_key_file, "r") as keyfile:
+                #     priv_key = keyfile.read()
+
+        priv_key_file = conf['default']['priv_key_file']
+        _CONF["current_user_priv_key"] = priv_key_file
+
+        cert_file = conf['default']['cert_file']
+        if cert_file is not None:
+            with open(cert_file, "r") as cert_file:
+                _CONF["current_user_cert"] = cert_file.read()
+
+        _CONF["nonce_ctr"] = 0
+        print(_CONF)
+    except KeyError as e:
+        print("Please add the required fields to your config file")
+        raise e
+
+
+def init_client(config=None, remote_addr=None, user_name=None, client_list=[],
         sym_key_file=None, priv_key_file=None, cert_file=None):
     """
     Initialize the client. Set up the client's keys, and specify the IP address of the enclave server.
 
     Parameters
     ----------
+    config: file
+        Configuration file containing the client parameters. If this is provided, the other arguments are ignored.
     remote_addr: str
         IP address of remote server running the enclave
     user_name : str
@@ -2501,7 +2569,9 @@ def init_client(remote_addr=None, user_name=None, client_list=[],
     cert_file : str
         Path to file containing user's public key certificate
     """
-    # TODO(rishabh): Verify parameters
+    if config is not None:
+        init_config(config)
+        return
 
     _CONF["remote_addr"] = remote_addr;
     _CONF["current_user"] = user_name


### PR DESCRIPTION
Update the `init_client` API to accept a config file as an alternative. Still need to update the docs though.