### PR TITLE
Add descriptive error message to sha256 mismatch

### DIFF
--- a/host/src/c_api/c_api.cc
+++ b/host/src/c_api/c_api.cc
@@ -968,7 +968,7 @@ bool attest_remote_report(
   }
 
   if (memcmp(parsed_report.report_data, sha256, sizeof(sha256)) != 0) {
-    LOG(FATAL) << "Remote attestation failed. SHA256 mismatch.";
+    LOG(FATAL) << "Remote attestation failed. SHA256 mismatch. There is likely a client list mismatch.";
   }
   return true;
 }

--- a/host/src/c_api/c_api_mc.cc
+++ b/host/src/c_api/c_api_mc.cc
@@ -704,7 +704,7 @@ bool attest_remote_report(
   }
 
   if (memcmp(parsed_report.report_data, sha256, sizeof(sha256)) != 0) {
-    LOG(FATAL) << "Remote attestation failed. SHA256 mismatch.";
+    LOG(FATAL) << "Remote attestation failed. SHA256 mismatch. There is likely a client list mismatch.";
   }
   return true;
 }


### PR DESCRIPTION
Adds descriptive error message to hash mismatch during report verification.