### PR TITLE
Fix remote calling of load_model()

### DIFF
--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -52,10 +52,7 @@ print("\nModel Predictions: ")
 predictions, num_preds = booster.predict(dtest, decrypt=False)
 
 # Decrypt predictions
-pre = booster.decrypt_predictions(predictions, num_preds)
-
-for i in range(10):
-    print(pre[i])
+print(booster.decrypt_predictions(predictions, num_preds))
 
 # Get fscores of model
 print("\nModel Feature Importance: ")

--- a/demo/python/basic/secure-xgboost-demo.py
+++ b/demo/python/basic/secure-xgboost-demo.py
@@ -52,7 +52,10 @@ print("\nModel Predictions: ")
 predictions, num_preds = booster.predict(dtest, decrypt=False)
 
 # Decrypt predictions
-print(booster.decrypt_predictions(predictions, num_preds))
+pre = booster.decrypt_predictions(predictions, num_preds)
+
+for i in range(10):
+    print(pre[i])
 
 # Get fscores of model
 print("\nModel Feature Importance: ")

--- a/demo/python/remote-control/client/client.py
+++ b/demo/python/remote-control/client/client.py
@@ -55,6 +55,9 @@ def run(channel_addr, sym_key_file, priv_key_file, cert_file):
 
     booster.save_model(HOME_DIR + "demo/python/remote-control/client/modelfile.model")
 
+    booster = xgb.Booster()
+    booster.load_model(HOME_DIR + "demo/python/remote-control/client/modelfile.model")
+
     # Get encrypted predictions
     print("\nModel Predictions: ")
     predictions, num_preds = booster.predict(dtest, decrypt=False)

--- a/python-package/securexgboost/core.py
+++ b/python-package/securexgboost/core.py
@@ -3007,7 +3007,7 @@ class RemoteAPI:
             ctypes.c_uint32(nonce_ctr),
             ctypes.byref(out_sig),
             ctypes.byref(out_sig_len),
-            signers,
+            from_pystr_to_cstr(signers),
             c_signatures,
             c_sig_lengths))
         return out_sig, out_sig_len.value


### PR DESCRIPTION
Previously, there was a bug when invoking `load_model()` remotely. This PR fixes that bug and adds a remote invocation of `load_model()` in the `remote-control()` demo.