### PR TITLE
Update docs with necessary requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following instructions will create an environment from scratch. Alternativel
     sudo bash cmake-3.15.6-Linux-x86_64.sh --skip-license --prefix=/usr/local
 
     sudo apt-get install -y libmbedtls-dev python3-pip
-    pip3 install numpy pandas sklearn numproto grpcio grpcio-tools   
+    pip3 install numpy pandas sklearn numproto grpcio grpcio-tools requests
     ```
 
 4. Clone Secure XGBoost.

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -71,7 +71,7 @@ Installing Secure XGBoost Dependencies
    .. code-block:: bash
 
       sudo apt-get install -y libmbedtls-dev python3-pip
-      pip3 install numpy pandas sklearn numproto grpcio grpcio-tools kubernetes   
+      pip3 install numpy pandas sklearn numproto grpcio grpcio-tools requests
 
 
 ***********************

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,3 +10,4 @@ numproto
 sklearn
 grpcio
 grpcio-tools
+requests


### PR DESCRIPTION
Running `secure-xgboost/host/dmlc-core/tracker/dmlc_tracker` requires the `requests` python package which isn't currently specified in the requirements.

Also I wasn't sure but it seems that kubernetes is an optional additional and not a requirement so I removed it from the requirements list. But if it is required somewhere I will add it back in.