### PR TITLE
Fix GitHub action to publish documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Publish Documentation
+name: docs
 
 on:
   push:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,6 @@ on:
     branches:    
       - master
 
-  pull_request:
-      branches:
-        - master
-
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Commit documentation changes
         run: |
           git clone https://github.com/mc2-project/secure-xgboost.git --branch gh-pages --single-branch gh-pages
-          cp -r doc/build/html/* gh-pages/
+          cp -r doc/_build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll
           git config --local user.email "action@github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches:    
       - master
 
+  pull_request:
+      branches:
+        - master
+
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -48,7 +52,6 @@ jobs:
           cd build
           cmake ..
           make -j4
-          cd ../..
 
       - name: Install Python dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Secure XGBoost
 
 [![Build Status](https://travis-ci.org/mc2-project/secure-xgboost.svg?branch=master)](https://travis-ci.org/mc2-project/secure-xgboost)
-[![Documentation Status](https://readthedocs.org/projects/secure-xgboost/badge/?version=latest)](https://secure-xgboost.readthedocs.io/en/latest/?badge=latest)
+![Documentation Status](https://github.com/mc2-project/secure-xgboost/actions/workflows/main.yml/badge.svg)
+<!-- [![Documentation Status](https://readthedocs.org/projects/secure-xgboost/badge/?version=latest)](https://secure-xgboost.readthedocs.io/en/latest/?badge=latest) -->
 ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Secure XGBoost
 
 [![Build Status](https://travis-ci.org/mc2-project/secure-xgboost.svg?branch=master)](https://travis-ci.org/mc2-project/secure-xgboost)
-![Documentation Status](https://github.com/mc2-project/secure-xgboost/actions/workflows/main.yml/badge.svg)
-<!-- [![Documentation Status](https://readthedocs.org/projects/secure-xgboost/badge/?version=latest)](https://secure-xgboost.readthedocs.io/en/latest/?badge=latest) -->
-![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg)
+[![Documentation Status](https://github.com/mc2-project/secure-xgboost/actions/workflows/docs.yml/badge.svg)
+[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Secure XGBoost is a library that leverages secure enclaves and data-oblivious algorithms to enable the **collaborative training of and inference using [XGBoost](https://github.com/dmlc/xgboost) models on encrypted data**. 


### PR DESCRIPTION
This PR fixes the GitHub action to publish documentation to https://mc2-project.github.io/secure-xgboost/.
It also updates the README badge to reflect the new docs site.