### PR TITLE
Upgrade to Open Enclave 0.17.1, add Python package requirements

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
    
       - name: Install apt package dependencies
         run: |
-          # Install OpenEnclave 0.12.0
+          # Install OpenEnclave 0.17.1
           echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
@@ -33,7 +33,7 @@ jobs:
           wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
           sudo apt update
-          sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 enchant
+          sudo apt -y install clang-8 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
 
           # CMake
           wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
    
       - name: Install apt package dependencies
         run: |
-          # Install OpenEnclave 0.12.0
+          # Install OpenEnclave 0.17.1
           echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
@@ -41,7 +41,7 @@ jobs:
           wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
           sudo apt update
-          sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 enchant
+          sudo apt -y install clang-8 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
 
           # CMake
           wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
   - sudo apt-get -qq update
   # Install dependencies
-  - sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0 libmbedtls-dev
+  - sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1 libmbedtls-dev
   - wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
   - sudo bash cmake-3.15.6-Linux-x86_64.sh --skip-license --prefix=/usr/local
   - export PATH=/usr/local:/usr/local/bin:$PATH 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,13 +112,16 @@ endif(LVI_MITIGATION)
 
 set_default_configuration_release()
 
-set(OE_MIN_VERSION 0.12.0)
+set(OE_MIN_VERSION 0.17.1)
 if (LVI_MITIGATION)
     # Configure the cmake to use customized compilation toolchain.
     # This package has to be added before `project()`.
     find_package(OpenEnclave-LVI-Mitigation ${OE_MIN_VERSION} CONFIG REQUIRED)
 endif()
 find_package(OpenEnclave ${OE_MIN_VERSION} CONFIG REQUIRED)
+set(OE_CRYPTO_LIB
+    mbedtls
+    CACHE STRING "Crypto library used by enclaves.")
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/host)
 add_subdirectory(${PROJECT_SOURCE_DIR}/enclave)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The following instructions will create an environment from scratch. Note that Se
 
 Alternatively, you can use the provided [Docker image](https://hub.docker.com/repository/docker/mc2project/ubuntu-oe0.9) if you want to run everything in simulation mode locally. If you use Docker, you'll need to clone Secure XGBoost locally and mount it to the container's `/root/secure-xgboost/` directory [using the `-v` flag](https://stackoverflow.com/questions/23439126/how-to-mount-a-host-directory-in-a-docker-container) when starting the container.
 
-1. Install the Open Enclave SDK (0.12.0) and the Intel SGX DCAP driver by following [these instructions](https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md). In Step 3 of the instructions, install Open Enclave version 0.12.0 by specifying the version:
+1. Install the Open Enclave SDK (0.17.1) and the Intel SGX DCAP driver by following [these instructions](https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md). In Step 3 of the instructions, install Open Enclave version 0.17.1 by specifying the version:
 
     ```sh
-    sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0
+    sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
     ```
 
 2. Configure the required environment variables.
@@ -127,7 +127,6 @@ For more background on enclaves and data-obliviousness, additional tutorials, an
 * [CCS PPMLP Paper](https://arxiv.org/pdf/2010.02524.pdf)
 * [Blog Post](https://towardsdatascience.com/secure-collaborative-xgboost-on-encrypted-data-ac7bc0ec7741)
 * RISE Camp 2020 [Tutorial](https://github.com/mc2-project/risecamp/tree/risecamp2020) and [Walkthrough](https://youtu.be/-kK-YCjqABs?t=312)
-* [Docker image for development](https://hub.docker.com/repository/docker/mc2project/ubuntu-oe0.12)
 
 ## Getting Involved
 * mc2-dev@googlegroups.com: For questions and general discussion

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Alternatively, you can use the provided [Docker image](https://hub.docker.com/re
 1. Install the Open Enclave SDK (0.17.1) and the Intel SGX DCAP driver by following [these instructions](https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md). In Step 3 of the instructions, install Open Enclave version 0.17.1 by specifying the version:
 
     ```sh
-    sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
+    sudo apt -y install clang-8 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
+
     ```
 
 2. Configure the required environment variables.

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -37,7 +37,8 @@ Installing the Open Enclave SDK
 
    .. code-block:: bash
 
-      sudo apt -y install clang-7 libssl-dev gdb libprotobuf10 libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
+      sudo apt -y install clang-8 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
+
 
    .. note:: You may also build the SDK in "simulation mode" on a machine without SGX support (e.g., for local development and testing). To build in simulation mode, follow the instructions `here <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_oe_sdk-Simulation.md>`_ instead. Notably, these instructions require that you skip the driver installation step.
 

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -30,14 +30,14 @@ to open an issue on `GitHub <https://github.com/mc2-project/secure-xgboost/issue
 Installing the Open Enclave SDK
 *******************************
 
-1. Install the Open Enclave SDK (v0.12.0) and the Intel SGX DCAP driver.  
+1. Install the Open Enclave SDK (v0.17.1) and the Intel SGX DCAP driver.  
    If building on an SGX-enabled machine, follow the instructions `here <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md>`_. 
    
-   **Note**: In step 3 of the instructions, make sure that you install Open Enclave version 0.12.0 by specifying the version
+   **Note**: In step 3 of the instructions, make sure that you install Open Enclave version 0.17.1 by specifying the version.
 
    .. code-block:: bash
 
-      sudo apt -y install clang-7 libssl-dev gdb libprotobuf10 libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0
+      sudo apt -y install clang-7 libssl-dev gdb libprotobuf10 libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.17.1
 
    .. note:: You may also build the SDK in "simulation mode" on a machine without SGX support (e.g., for local development and testing). To build in simulation mode, follow the instructions `here <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_oe_sdk-Simulation.md>`_ instead. Notably, these instructions require that you skip the driver installation step.
 

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -116,9 +116,9 @@ if (LVI_MITIGATION)
     # Helper to enable compiler options for LVI mitigation.
     apply_lvi_mitigation(xgboost_enclave)
     # Link against LVI-mitigated libraries.
-    target_link_libraries(xgboost_enclave openenclave::oeenclave-lvi-cfg openenclave::oelibcxx-lvi-cfg openenclave::oehostfs-lvi-cfg openenclave::oehostsock-lvi-cfg openenclave::oehostresolver-lvi-cfg)
+    target_link_libraries(xgboost_enclave openenclave::oeenclave-lvi-cfg openenclave::oecrypto${OE_CRYPTO_LIB}-lvi-cfg openenclave::oelibcxx-lvi-cfg openenclave::oehostfs-lvi-cfg openenclave::oehostsock-lvi-cfg openenclave::oehostresolver-lvi-cfg)
 else()
-    target_link_libraries(xgboost_enclave openenclave::oeenclave openenclave::oelibcxx openenclave::oehostfs openenclave::oehostsock openenclave::oehostresolver)
+    target_link_libraries(xgboost_enclave openenclave::oeenclave openenclave::oecrypto${OE_CRYPTO_LIB} openenclave::oelibcxx openenclave::oehostfs openenclave::oehostsock openenclave::oehostresolver)
 endif()
 
 # Sign enclave

--- a/python-package/securexgboost/remote_server.py
+++ b/python-package/securexgboost/remote_server.py
@@ -456,7 +456,6 @@ class RemoteServicer(remote_pb2_grpc.RemoteServicer):
         try:
             if not globals()["is_orchestrator"]:
                 pem_key, key_size, nonce, nonce_size, client_list, client_list_size, remote_report, remote_report_size = self._serialize(remote_api.get_remote_report_with_pubkey_and_nonce, request)
-                print(type(pem_key))
                 return remote_pb2.Report(pem_key=pem_key, pem_key_size=key_size,
                     nonce=nonce, nonce_size=nonce_size,
                     client_list=client_list, client_list_size=client_list_size,

--- a/python-package/securexgboost/remote_server.py
+++ b/python-package/securexgboost/remote_server.py
@@ -456,6 +456,7 @@ class RemoteServicer(remote_pb2_grpc.RemoteServicer):
         try:
             if not globals()["is_orchestrator"]:
                 pem_key, key_size, nonce, nonce_size, client_list, client_list_size, remote_report, remote_report_size = self._serialize(remote_api.get_remote_report_with_pubkey_and_nonce, request)
+                print(type(pem_key))
                 return remote_pb2.Report(pem_key=pem_key, pem_key_size=key_size,
                     nonce=nonce, nonce_size=nonce_size,
                     client_list=client_list, client_list_size=client_list_size,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy==1.19.0
+scikit-learn
+pandas
+numproto
+grpcio
+grpcio-tools
+protobuf<=3.13.0
+requests


### PR DESCRIPTION
This PR upgrades Secure XGBoost to use Open Enclave 0.17.1, and also adds a `requirements.txt` file to enumerate all required Python packages