### PR TITLE
Fix compile error in gcc 11

### DIFF
--- a/enclave/src/learner.cc
+++ b/enclave/src/learner.cc
@@ -481,7 +481,7 @@ class LearnerConfiguration : public Learner {
         if (is_parameter(kv.first)) {
           auto parameter = get<Object const>(kv.second);
           std::transform(parameter.begin(), parameter.end(), std::back_inserter(keys),
-                         [](std::pair<std::string const&, Json const&> const& kv) {
+                         [](std::pair<std::string const&, Json const&> const kv) {
                            return kv.first;
                          });
         } else if (IsA<Object>(kv.second)) {


### PR DESCRIPTION
If using gcc 11, Secure XGBoost would fail to compile due to the following error:

```
In file included from /opt/openenclave/include/openenclave/3rdparty/libcxx/algorithm:641,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/__string:57,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/string_view:176,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/string:505,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/__locale:15,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/ios:216,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/ostream:138,
                 from /opt/openenclave/include/openenclave/3rdparty/libcxx/istream:164,
                 from /home/chester/opaque/xgb/enclave/../include/dmlc/io.h:10,
                 from /home/chester/opaque/xgb/enclave/src/learner.cc:8:
/opt/openenclave/include/openenclave/3rdparty/libcxx/type_traits: In instantiation of ‘struct std::__1::__decay<const std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, const xgboost::Json&>&, true>’:
/opt/openenclave/include/openenclave/3rdparty/libcxx/type_traits:1368:73:   required from ‘struct std::__1::decay<const std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, const xgboost::Json&>&&>’
/opt/openenclave/include/openenclave/3rdparty/libcxx/utility:404:16:   required by substitution of ‘template<class _Tuple, typename std::__1::enable_if<typename std::__1::conditional<(std::__1::__tuple_like_with_size<_Tuple, 2, typename std::__1::__uncvref<_Tp>::type>::value && (! std::__1::is_same<typename std::__1::decay<_Tp>::type, std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, xgboost::Json> >::value)), std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, xgboost::Json>::_CheckTupleLikeConstructor, std::__1::__check_tuple_constructor_fail>::type::__enable_implicit<_Tuple>(), bool>::type <anonymous> > std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, xgboost::Json>::pair(_Tuple&&) [with _Tuple = const std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, const xgboost::Json&>&&; typename std::__1::enable_if<typename std::__1::conditional<(std::__1::__tuple_like_with_size<_Tuple, 2, typename std::__1::__uncvref<_Tp>::type>::value && (! std::__1::is_same<typename std::__1::decay<_Tp>::type, std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, xgboost::Json> >::value)), std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, xgboost::Json>::_CheckTupleLikeConstructor, std::__1::__check_tuple_constructor_fail>::type::__enable_implicit<_Tuple>(), bool>::type <anonymous> = <missing>]’
/home/chester/opaque/xgb/enclave/src/learner.cc:526:38:   required from here
/opt/openenclave/include/openenclave/3rdparty/libcxx/type_traits:1359:30: error: forming pointer to reference type ‘std::__1::remove_extent<const std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, const xgboost::Json&>&>::type’ {aka ‘const std::__1::pair<const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, const xgboost::Json&>&’}
 1359 |                      >::type type;
      |                              ^~~~
enclave/CMakeFiles/xgboost_enclave.dir/build.make:514: recipe for target 'enclave/CMakeFiles/xgboost_enclave.dir/src/learner.cc.o' failed
make[2]: *** [enclave/CMakeFiles/xgboost_enclave.dir/src/learner.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

Strangely, this error would not manifest if using gcc 7 with Open Enclave. Passing the pair by value instead of by reference seems to fix this compile error.